### PR TITLE
Contact Schema and Routes

### DIFF
--- a/tracker-rest/controllers/contact_controller.mjs
+++ b/tracker-rest/controllers/contact_controller.mjs
@@ -1,0 +1,86 @@
+import Contact from '../models/contact_model.mjs';
+
+// Create a new contact
+export const createContact = async (req, res) => {
+    try {
+        // Create contact from request body
+        const newContact = new Contact({
+            ...req.body,
+            user: req.user._id
+        });
+        // Save and send contact
+        await newContact.save();
+        res.status(201).json(newContact);
+    } catch (error) {
+        // Handle error
+        res.status(400).json({ message: error.message });
+    }
+};
+
+// Get a particular contact
+export const getContact = async (req, res) => {
+    try {
+        // Find contact from route param :_id
+        const contact = await Contact.findOne({ _id: req.params.id, user: req.user._id });
+        // If contact not found
+        if (!contact) {
+            return res.status(404).json({ message: 'Contact not found' });
+        }
+        // Send contact
+        res.status(200).json(contact);
+    } catch (error) {
+        // Handle error
+        res.status(500).json({ message: error.message });
+    }
+};
+
+// Get all contacts for the authenticated user
+export const getContacts = async (req, res) => {
+    try {
+        // Find all contacts
+        const contacts = await Contact.find({ user: req.user._id });
+        // Send all contacts
+        res.status(200).json(contacts);
+    } catch (error) {
+        // Handle error
+        res.status(500).json({ message: error.message });
+    }
+};
+
+// Update a contact
+export const updateContact = async (req, res) => {
+    try {
+        // Find contact from route param :_id, and update the contact
+        const contact = await Contact.findOneAndUpdate(
+            { _id: req.params.id, user: req.user._id },
+            req.body,
+            { new: true }
+        );
+        // If contact not found
+        if (!contact) {
+            return res.status(404).json({ message: 'Contact not found to update' });
+        }
+        // Send updated contact
+        res.status(200).json(contact);
+    } catch (error) {
+        // Handle error
+        res.status(400).json({ message: error.message });
+    }
+};
+
+// Delete a contact
+export const deleteContact = async (req, res) => {
+    try {
+        // Find contact from route param :_id, and delete the contact
+        const contact = await Contact.findOneAndDelete({ _id: req.params.id, user: req.user._id });
+        // If contact not found
+        if (!contact) {
+            return res.status(404).json({ message: 'Contact not found to delete' });
+        }
+        // Send message to confirm deletion
+        res.status(200).json({ message: 'Contact deleted' });
+    } catch (error) {
+        // Handle error
+        res.status(500).json({ message: error.message });
+    }
+};

--- a/tracker-rest/models/contact_model.mjs
+++ b/tracker-rest/models/contact_model.mjs
@@ -1,0 +1,77 @@
+import mongoose from 'mongoose';
+
+// Schema for mongo database for contacts
+const contactSchema = new mongoose.Schema({
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+        required: true
+    },
+    name: {
+        type: String,
+        required: true
+    },
+    company: {
+        type: String,
+        required: true
+    },
+    email: {
+        type: String,
+        required: true
+    },
+    phoneNumbers: [{
+        number: {
+            type: String,
+            required: true
+        },
+        type: {
+            type: String,
+            enum: ['Mobile', 'Work', 'Home', 'Other'],
+            default: 'Mobile'
+        }
+    }],
+    notes: {
+        type: String
+    },
+    contactType: {
+        type: String,
+        enum: ['Recruiter', 'Peer', 'Mentor', 'Alumni', 'Company Representative', 'Other'],
+        required: true
+    },
+    interactionType: {
+        type: String,
+        enum: ['Email', 'LinkedIn', 'In-person', 'Phone call', 'Online event', 'Other']
+    },
+    sourceOfContact: {
+        type: String,
+        enum: ['Job Fair', 'Referral', 'LinkedIn', 'Company Website', 'Networking Event', 'Other']
+    },
+    statusOfInteraction: {
+        type: String,
+        enum: ['Awaiting Response', 'In Discussion', 'Need to Follow Up', 'Closed', 'Other']
+    },
+    strengthOfConnection: {
+        type: Number,
+        min: 1,
+        max: 5
+    },
+    referralPotential: {
+        type: Boolean
+    },
+    preferredContactMethod: {
+        type: String,
+        enum: ['Email', 'Phone', 'LinkedIn', 'Other']
+    },
+    dateAdded: {
+        type: Date,
+        default: Date.now
+    },
+    followUpDate: {
+        type: Date
+    },
+    lastContactedDate: {
+        type: Date
+    }
+});
+
+export default mongoose.model('Contacts', contactSchema);

--- a/tracker-rest/route-testing/contact-requests.http
+++ b/tracker-rest/route-testing/contact-requests.http
@@ -1,0 +1,275 @@
+### Request 1: Create contact without token (should fail - "Please authenticate")
+POST http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: NO_TOKEN_PROVIDED
+
+{
+    "name": "Jane Doe",
+    "company": "XYZ Corp",
+    "email": "jane.doe@example.com",
+    "contactType": "Peer"
+}
+
+### Request 2: Get contacts without token (should fail - "Please authenticate")
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: NO_TOKEN_PROVIDED
+
+{
+    
+}
+
+### Request 3: Register a new user: testuser1
+POST http://localhost:3000/users/register HTTP/1.1
+content-type: application/json
+
+{
+    "username": "testuser1",
+    "password": "Test@1234"
+}
+
+### Request 4: Login to get the token for testuser1
+POST http://localhost:3000/users/login HTTP/1.1
+content-type: application/json
+
+{
+    "username": "testuser1",
+    "password": "Test@1234"
+}
+
+### Request 5: Create a new contact for testuser1 (using token for testuser1 from login above)
+POST http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "John Doe",
+    "company": "ABC Corp",
+    "email": "john.doe@example.com",
+    "phoneNumbers": [
+        {
+            "number": "123-456-7890",
+            "type": "Mobile"
+        },
+        {
+            "number": "098-765-4321",
+            "type": "Work"
+        }
+    ],
+    "notes": "Met at a conference.",
+    "contactType": "Recruiter",
+    "interactionType": "In-person",
+    "sourceOfContact": "Networking Event",
+    "statusOfInteraction": "In Discussion",
+    "strengthOfConnection": 4,
+    "referralPotential": true,
+    "preferredContactMethod": "Email",
+    "dateAdded": "2022-08-15T00:00:00.000Z",
+    "followUpDate": "2023-09-01T00:00:00.000Z",
+    "lastContactedDate": "2023-08-01T00:00:00.000Z"
+}
+
+### Request 6: Create another contact for testuser1 (using token for testuser1)
+POST http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "Jane Doe",
+    "company": "Coder Corp",
+    "email": "jane.doe@example.com",
+    "notes": "Met at a networking event.",
+    "phoneNumbers": [
+        {
+            "number": "012-345-6789",
+            "type": "Work"
+        }
+    ],
+    "contactType": "Alumni",
+    "interactionType": "Online event",
+    "sourceOfContact": "Networking Event",
+    "statusOfInteraction": "Awaiting Response",
+    "strengthOfConnection": 2,
+    "referralPotential": false,
+    "preferredContactMethod": "Other",
+    "followUpDate": "2023-09-01T00:00:00.000Z",
+    "lastContactedDate": "2023-08-01T00:00:00.000Z"
+}
+
+### Request 7: Get all contacts for testuser1 (using token for testuser1)
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 8: Update a testuser1 contact (using token for testuser1 and the contact _id [obtained from the get route above])
+PUT http://localhost:3000/contacts/REPLACE_WITH_CONTACT_id_TO_UPDATE HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "John Updated",
+    "company": "XYZ Updated",
+    "email": "john.updated@example.com"
+}
+
+### Reqeuest 9: Get all contacts for testuser1 (using token for testuser1) to confirm contact update
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 10: Update a particular contact phonenumber for testuser1 (using token for testuser1, the contact _id & phoneNumber _id [obtained from the get route above]. To avoid losing data, send complete phonenumber array - updating 1 number and leaving other as is)
+PUT http://localhost:3000/contacts/REPLACE_WITH_CONTACT_id_TO_UPDATE HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "John Updated Again",
+    "phoneNumbers": [
+        {
+            "_id": "REPLACE_WITH_PHONENUMBER_id",
+            "number": "999-999-9999",
+            "type": "Other"
+        },
+        {
+            "_id": "REPLACE_WITH_PHONENUMBER_id",
+            "number": "098-765-4321",
+            "type": "Work"
+        }
+    ]
+}
+
+### Request 11: Get all contacts for testuser1 (using token for testuser1) to confirm the contact was updated
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 12: Delete contact for testuser1 (using token for testuser1, the contact _id [obtained from the get route above])
+DELETE http://localhost:3000/contacts/REPLACE_WITH_CONTACT_id_TO_DELETE HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 13: Get all contacts for testuser1 (using token for testuser1) to confirm the contact was deleted
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 14: Update non-existant contact (using token for testuser1 - should fail given the invalid _id)
+PUT http://localhost:3000/contacts/65bbf226c8ba59cf6861deca HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "Non Existent",
+    "company": "None",
+    "email": "nonexistent@example.com"
+}
+
+### Request 15: Delete non-existant contact (using token for testuser1 - should fail given the invalid _id)
+DELETE http://localhost:3000/contacts/65bbf226c8ba59cf6861deca HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 16: Register a new user: testuser2 (to check that this new user can't see the other users contacts)
+POST http://localhost:3000/users/register HTTP/1.1
+content-type: application/json
+
+{
+    "username": "testuser2",
+    "password": "Test@54321"
+}
+
+### Request 17: Login to get the token for testuser2
+POST http://localhost:3000/users/login HTTP/1.1
+content-type: application/json
+
+{
+    "username": "testuser2",
+    "password": "Test@54321"
+}
+
+### Request 18: Get all contacts for testuser2 (using token for testuser2 - there should be no contacts for this new user)
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 19: Create a new contact for testuser2 (using token for testuser2 - from login above)
+POST http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+    "name": "Bob Roberts",
+    "company": "AI Co",
+    "email": "bob.b@example.com",
+    "phoneNumbers": [
+        {
+            "number": "000-111-1234",
+            "type": "Other"
+        }
+    ],
+    "notes": "Met through a friend.",
+    "contactType": "Peer",
+    "interactionType": "Email",
+    "sourceOfContact": "Referral",
+    "statusOfInteraction": "Closed",
+    "strengthOfConnection": 5,
+    "referralPotential": true,
+    "preferredContactMethod": "Phone",
+    "followUpDate": "2023-10-08T00:00:00.000Z",
+    "lastContactedDate": "2024-01-05T00:00:00.000Z"
+}
+
+### Request 20: Get all contacts for testuser2 (using token for testuser2 - should only see new user's contact and not testuser1 contacts)
+GET http://localhost:3000/contacts HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 21: Get specific contact for testuser2 (using token for testuser2, contact _id [obtained from get route above])
+GET http://localhost:3000/contacts/REPLACE_WITH_CONTACT_id_TO_GET HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}
+
+### Request 22: Get specific contact that doesn't exist for testuser2 (using token for testuser2)
+GET http://localhost:3000/contacts/65bbf226c8ba59cf6861deca HTTP/1.1
+content-type: application/json
+Authorization: REPLACE_WITH_TOKEN
+
+{
+
+}

--- a/tracker-rest/server.mjs
+++ b/tracker-rest/server.mjs
@@ -2,6 +2,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import 'dotenv/config';
 import * as auth from './controllers/auth_controller.mjs'
+import * as contact from './controllers/contact_controller.mjs';
 import { authMiddleware } from './middleware/auth_middleware.mjs';
 
 // Express middleware to parse incoming requests with JSON payloads
@@ -34,6 +35,13 @@ app.get('/users/user-info', authMiddleware, auth.userDetail);
 // Routes to update and delete user (protected routes - must be auth'd)
 app.put('/users/update', authMiddleware, auth.updateUser);
 app.delete('/users/delete', authMiddleware, auth.deleteUser);
+
+// Routes to create/get/update/delete a user's contact (protected routes - must be auth'd)
+app.post('/contacts', authMiddleware, contact.createContact);
+app.get('/contacts', authMiddleware, contact.getContacts);
+app.get('/contacts/:id', authMiddleware, contact.getContact);
+app.put('/contacts/:id', authMiddleware, contact.updateContact);
+app.delete('/contacts/:id', authMiddleware, contact.deleteContact);
 
 /* ROUTES END */
 


### PR DESCRIPTION
I wanted to make sure the custom middleware auth works (i.e. an auth'd user should only be authorized to see their contacts). Tested code to ensure the auth works for various CRUD operations, I've tested all the routes and all tests passed. So the Contact schema and Contact routes have been implemented.

Summary of changes:

**contact_model.mjs:**
- Contact schema created (bounced ideas w/ AI to think of useful fields to build metrics later - when connecting the frontend/backend later will build drop downs, etc. for all the enum values for error handling/consistency)

**contact_controller.mjs:**
- Basic CRUD routes created for contacts for full auth testing, all routes tested and working with user auth (token). An authorized token user can create new contact, get a particular contact (by param:_id), get all contacts, update contact (by param:_id), delete contact (by param:_id)

**server.mjs:**
- Added the contact controller routes to the server app

**contact-requests.http:**
- Added tests for all routes, all tests passed. A user should only be able to see their contacts, and this seems to be working.
- I left placeholders for the tokens/_ids if it helps for clarity

_Example showing a login to get a token:_

![Screenshot 2024-02-01 at 1 38 36 PM](https://github.com/alesiram/cs467_capstone/assets/87046544/85811512-2ec4-448e-9b95-8117c1eb09d0)

_Creating a new contact for the user with their token in authorization header:_

![Screenshot 2024-02-01 at 1 39 35 PM](https://github.com/alesiram/cs467_capstone/assets/87046544/919c937c-bc03-45b5-989b-60ce1d497032)

Get a specific contact by their _id:
![Screenshot 2024-02-01 at 1 50 21 PM](https://github.com/alesiram/cs467_capstone/assets/87046544/82b89289-1722-44d9-9385-9a73bc8498fb)

note: built/scoped approaches w/ ChatGPT 4.0/Bard AI