### PR TITLE
Contact connect front back integration

### DIFF
--- a/tracker-ui/src/components/ContactComponents/AddContactModal.js
+++ b/tracker-ui/src/components/ContactComponents/AddContactModal.js
@@ -1,59 +1,337 @@
 import React, { useState } from 'react';
 
 // Modal to add a new contact
-const AddContactModal = ({ show, onClose, onSave }) => {
+const AddContactModal = ({ show, onClose, createContact, contacts, setContacts }) => {
 
-    // Store new contact details
-    const [newContact, setNewContact] = useState({
+    // For toggling the success message
+    const [showSuccess, setShowSuccess] = useState(false);
+
+    // For checking if contact name already exists
+    const [nameExists, setNameExists] = useState(false);
+
+    // Manage the intial contact state
+    const initialContactState = {
         name: '',
         company: '',
         email: '',
-        // PLACEHOLDER - ADD ALL FIELDS FROM SCHEMA
+        phoneNumbers: [],
+        notes: '',
+        contactType: '',
+        interactionType: '',
+        sourceOfContact: '',
+        statusOfInteraction: '',
+        strengthOfConnection: 1,
+        referralPotential: false,
+        preferredContactMethod: '',
+        dateAdded: new Date().toISOString().split('T')[0], // Current date in 'yyyy-MM-dd' format
+        followUpDate: null,
+        lastContactedDate: null,
+    };
+
+    // Store new contact details (start with initialized state)
+    const [newContact, setNewContact] = useState({
+        ...initialContactState
     });
 
     // Handle event change
     const handleChange = (e) => {
+        // Get event target details
         const { name, value } = e.target;
+        // Update new contact state property with value (as Number for strength of connection)
         setNewContact(prevState => ({
             ...prevState,
-            [name]: value
+            [name]: name === 'strengthOfConnection' ? Number(value) : value,
+        }));
+        // Update naming associated with strength
+        if (name === "strengthOfConnection") {
+            updateStrengthDescription(value);
+        }
+        // Check for contact name uniqueness to warn user
+        else if (name === "name") {
+            const exists = contacts.some(contact => contact.name.toLowerCase() === value.toLowerCase());
+            setNameExists(exists);
+        }
+    };
+
+    // Handle submission for creating new contact
+    const handleSubmit = async (e) => {
+        // Prevent default form action
+        e.preventDefault();
+        // Prepare the new contact to save in the database
+        const preparedContact = {
+            name: newContact.name, // required
+            company: newContact.company, // required
+            email: newContact.email, // required
+            phoneNumbers: newContact.phoneNumbers.filter(phoneNumber => phoneNumber.number.trim() !== ''), // remove any blanks
+            notes: newContact.notes ? newContact.notes : null,
+            contactType: newContact.contactType, //required
+            interactionType: newContact.interactionType ? newContact.interactionType : null,
+            sourceOfContact: newContact.sourceOfContact ? newContact.sourceOfContact : null,
+            statusOfInteraction: newContact.statusOfInteraction ? newContact.statusOfInteraction : null,
+            strengthOfConnection: newContact.strengthOfConnection ? newContact.strengthOfConnection : 1,
+            referralPotential: newContact.referralPotential ? newContact.referralPotential : false,
+            preferredContactMethod: newContact.preferredContactMethod ? newContact.preferredContactMethod : null,
+            dateAdded: newContact.dateAdded ? new Date(newContact.dateAdded).toISOString().split('T')[0] : new Date().toISOString().split('T')[0], // date in 'yyyy-MM-dd' format
+            followUpDate: newContact.followUpDate ? new Date(newContact.followUpDate).toISOString().split('T')[0] : null,
+            lastContactedDate: newContact.lastContactedDate ? new Date(newContact.lastContactedDate).toISOString().split('T')[0] : null
+        };
+        try {
+            // Wait for the createContact() operation to complete
+            const savedContact = await createContact(preparedContact);
+            // Set the savedContact (returned from successful POST route) in the contacts
+            setContacts([...contacts, savedContact])
+            // Show the success modal
+            setShowSuccess(true);
+            // Set timeout to close the modal
+            setTimeout(() => {
+                // Show success message, reset the new contact state and name check, and close the modal
+                setShowSuccess(false);
+                setNewContact(initialContactState);
+                setNameExists(false);
+                onClose();
+            }, 1500)
+        } catch (error) {
+            // Handle error
+            console.log("Failed to save contact:", error);
+            alert("Failed to save contact");
+        }
+    };
+
+    // Handle phonenumber change in associated input field
+    const handlePhoneNumberChange = (index, fieldName, value) => {
+        setNewContact(prevState => {
+            const updatedPhoneNumbers = prevState.phoneNumbers.map((phoneNumber, i) => {
+                if (i === index) {
+                    return { ...phoneNumber, [fieldName]: value };
+                }
+                return phoneNumber;
+            });
+            return { ...prevState, phoneNumbers: updatedPhoneNumbers };
+        });
+    };
+
+    // Handle adding the phone number
+    const handleAddPhoneNumber = () => {
+        setNewContact(prevState => {
+            const newPhoneNumber = { number: '', type: 'Mobile' }; // Default to 'Mobile' type
+            return { ...prevState, phoneNumbers: [...prevState.phoneNumbers, newPhoneNumber] };
+        });
+    };
+
+    // Handle removing specific phone number
+    const handleRemovePhoneNumber = (index) => {
+        setNewContact(prevState => {
+            const updatedPhoneNumbers = prevState.phoneNumbers.filter((_, i) => i !== index);
+            return { ...prevState, phoneNumbers: updatedPhoneNumbers };
+        });
+    };
+
+    // Handle the check box change (referralPotential)
+    const handleCheckboxChange = (e) => {
+        const { name, checked } = e.target;
+        setNewContact(prevState => ({
+            ...prevState,
+            [name]: checked
         }));
     };
 
-    // Handle submission for new contact
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        onSave(newContact); // add new contact
-        onClose(); // Close modal after saving
+    // Handle clearning the form (set it back to initial state)
+    const handleClearForm = () => {
+        setNewContact(initialContactState);
+        setNameExists(false);
     };
+
+    // Update the strength descriptions in the form as user updates the slider
+    const updateStrengthDescription = (value) => {
+        // Possible strength descriptions (1 through 5)
+        const strengthDescriptions = {
+            '1': 'Very Low',
+            '2': 'Low',
+            '3': 'Moderate',
+            '4': 'High',
+            '5': 'Very High'
+        };
+        // Get the description based on the value (i.e. value = key)
+        const description = strengthDescriptions[value];
+        // Get and update the element to display the strength connection
+        const strengthDescriptionElement = document.getElementById('strengthDescription');
+        if (strengthDescriptionElement) {
+            strengthDescriptionElement.textContent = `${value} - ${description}`;
+        }
+    };
+
+    // Allowable database fields (to dynamically generate options)
+    const contactTypes = ['Recruiter', 'Peer', 'Mentor', 'Alumni', 'Company Representative', 'Other'];
+    const interactionTypes = ['Email', 'LinkedIn', 'In-person', 'Phone call', 'Online event', 'Other'];
+    const sourceOfContacts = ['Job Fair', 'Referral', 'LinkedIn', 'Company Website', 'Networking Event', 'Other'];
+    const statusOfInteractions = ['Awaiting Response', 'In Discussion', 'Need to Follow Up', 'Closed', 'Other'];
+    const preferredContactMethods = ['Email', 'Phone', 'LinkedIn', 'Other'];
+    const phoneNumberTypes = ['Mobile', 'Work', 'Home', 'Other'];
 
     // Return null if not displaying
     if (!show) return null;
 
     return (
+        // MODAL START
         <div className="add-contact-modal">
+            {/* MODAL CONTENT START */}
             <div className="add-contact-modal-content">
-                <span className="add-contact-modal-close" onClick={onClose}>&times;</span>
-                <h2>Add New Contact</h2>
-                <form onSubmit={handleSubmit}>
-                    <label>Name:</label>
-                    <input type="text" name="name" value={newContact.name} onChange={handleChange} />
+                {/* Display success message when user adds new contact, else display the form */}
+                {showSuccess ? (
+                    <>
+                        {/* Display the success message */}
+                        <div className="contact-form-success-message">
+                            <p>{newContact.name} has been added to your contacts!</p>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        {/* Display the form to add a new contact*/}
+                        <h2>Add New Contact</h2>
+                        {/* Close Modal Button */}
+                        <span className="contact-form-modal-close" onClick={onClose}>&times;</span>
+                        {/* FORM START */}
+                        <form onSubmit={handleSubmit} className='contact-add-edit-view-form'>
 
-                    <label>Company:</label>
-                    <input type="text" name="company" value={newContact.company} onChange={handleChange} />
+                            {/* Left hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-left-section">
+                                {/* Contact Name (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Name</label>
+                                <input type="text" name="name" value={newContact.name} onChange={handleChange} className="contact-add-edit-view-form-input" required maxLength="50" />
+                                {nameExists && <span style={{ color: 'red', marginBottom: '10px' }}>Warning: this contact name already exists</span>}
+                                {/* Contact Company (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Company</label>
+                                <input type="text" name="company" value={newContact.company} onChange={handleChange} className="contact-add-edit-view-form-input" required maxLength="50" />
+                                {/* Contact Email (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Email</label>
+                                <input type="email" name="email" value={newContact.email} onChange={handleChange} className="contact-add-edit-view-form-input" required maxLength="50" />
+                                {/* Contact Phone Numbers (dynamic addition - up to 5 allowed numbers */}
+                                <label>Phone Numbers</label>
+                                {newContact.phoneNumbers.map((phoneNumber, index) => (
+                                    <div key={index} className="contact-add-edit-view-form-phoneNumber-div">
+                                        <select name={`type-${index}`} value={phoneNumber.type} onChange={(e) => handlePhoneNumberChange(index, 'type', e.target.value)}>
+                                            {phoneNumberTypes.map(type => (
+                                                <option key={type} value={type}>{type}</option>
+                                            ))}
+                                        </select>
+                                        <input type="text" name={`number-${index}`} value={phoneNumber.number} onChange={(e) => handlePhoneNumberChange(index, 'number', e.target.value)} placeholder="Phone Number" maxLength={20} />
+                                        {(newContact.phoneNumbers.length > 1 || index === 0) && (
+                                            <button type="button" onClick={() => handleRemovePhoneNumber(index)}>Remove</button>
+                                        )}
+                                    </div>
+                                ))}
+                                {newContact.phoneNumbers.length < 5 && (
+                                    <button type="button" onClick={handleAddPhoneNumber}>Add Phone Number</button>
+                                )}
+                                {/* Contact Notes */}
+                                <label>Notes</label>
+                                <textarea name="notes" value={newContact.notes} onChange={handleChange} maxLength="200" className="contact-add-edit-view-form-notes-textarea" placeholder='Add your notes...'></textarea>
+                                <div>{200 - newContact.notes.length} characters remaining</div>
+                            </div>
 
-                    <label>Email:</label>
-                    <input type="email" name="email" value={newContact.email} onChange={handleChange} />
+                            {/* Right hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-right-section">
+                                {/* Container for all date inputs */}
+                                <div className="contact-add-edit-view-form-date-group">
+                                    {/* Contact Date Added */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Date Added</label>
+                                        <input type="date" name="dateAdded" value={newContact.dateAdded} onChange={handleChange} className="contact-add-edit-view-form-input" />
+                                    </div>
+                                    {/* Contact Follow Up Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Follow Up Date</label>
+                                        <input type="date" name="followUpDate" value={newContact.followUpDate || ''} onChange={handleChange} className="contact-add-edit-view-form-input" />
+                                    </div>
+                                    {/* Contact Last Contacted Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Last Contacted Date</label>
+                                        <input type="date" name="lastContactedDate" value={newContact.lastContactedDate || ''} onChange={handleChange} className="contact-add-edit-view-form-input" />
+                                    </div>
+                                </div>
+                                {/* Contact Type (required) */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label htmlFor="contactType" className="contact-add-edit-view-form-required-input-label">Contact Type</label>
+                                    <select name="contactType" value={newContact.contactType} onChange={handleChange} className="contact-add-edit-view-form-select" required>
+                                        <option value="">Select a Contact Type</option> {/* Ensures user makes an explicit choice */}
+                                        {contactTypes.sort().map((type) => (
+                                            <option key={type} value={type}>{type}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Interaction Type */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Interaction Type</label>
+                                    <select name="interactionType" value={newContact.interactionType} onChange={handleChange} className="contact-add-edit-view-form-select">
+                                        <option value="">Select Interaction Type</option>
+                                        {interactionTypes.sort().map((type) => (
+                                            <option key={type} value={type}>{type}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Source of Contact */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Source of Contact</label>
+                                    <select name="sourceOfContact" value={newContact.sourceOfContact} onChange={handleChange} className="contact-add-edit-view-form-select">
+                                        <option value="">Select Source of Contact</option>
+                                        {sourceOfContacts.sort().map((source) => (
+                                            <option key={source} value={source}>{source}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Status of Interaction */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Status of Interaction</label>
+                                    <select name="statusOfInteraction" value={newContact.statusOfInteraction} onChange={handleChange} className="contact-add-edit-view-form-select">
+                                        <option value="">Select Status of Interaction</option>
+                                        {statusOfInteractions.sort().map((status) => (
+                                            <option key={status} value={status}>{status}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Preferred Contact Method */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Preferred Contact Method</label>
+                                    <select name="preferredContactMethod" value={newContact.preferredContactMethod} onChange={handleChange} className="contact-add-edit-view-form-select">
+                                        <option value="">Select Preferred Contact Method</option>
+                                        {preferredContactMethods.sort().map((method) => (
+                                            <option key={method} value={method}>{method}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Container for Strength of Connection and Referral Potential */}
+                                <div className="contact-add-edit-view-form-div-attributes-group">
+                                    {/* Strength of Connection */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Strength of Connection</label>
+                                        <input type="range" name="strengthOfConnection" min="1" max="5" value={newContact.strengthOfConnection} onChange={handleChange} className="contact-add-edit-view-form-strength-of-connection-slider" />
+                                        <div id="strengthDescription" className="contact-add-edit-view-form-strenght-of-connection-description">1 - Very Low (Move the Slider)</div>
+                                    </div>
+                                    {/* Referral Potential */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Referral Potential</label>
+                                        <label className="contact-add-edit-view-form-label-referral-checkbox">
+                                            <input type="checkbox" name="referralPotential" checked={newContact.referralPotential} className='contact-add-edit-view-form-input-referral-checkbox' onChange={handleCheckboxChange} />
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
 
-                    {/* PLACEHOLDER - ADD ALL FIELDS */}
-                    <div className="under-construction-container">
-                        <span className="under-construction-text">🚧 More Fields To Be Added Soon</span>
-                    </div>
-                    {/* PLACEHOLDER END */}
+                            {/* Form Footer for the buttons */}
+                            <div className="contact-add-edit-view-form-footer">
+                                <button type="button" onClick={handleClearForm} className="add-contact-form-clear-inputs-button">Clear</button>
+                                <span className='contact-add-edit-view-form-required-input-label'>* Required Information *</span>
+                                <button type="submit">Save Contact</button>
+                            </div>
 
-                    <button type="submit">Save Contact</button>
-                </form>
+                            {/* FORM END */}
+                        </form>
+
+                    </>
+                )}
+                {/* MODAL CONTENT END */}
             </div>
+            {/* MODAL END */}
         </div>
     );
 };

--- a/tracker-ui/src/components/ContactComponents/ContactsTable.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsTable.js
@@ -20,7 +20,14 @@ const ContactsTable = ({ contacts, onEditClick, onDeleteClick, onViewClick }) =>
                             <td>{contact.name}</td>
                             <td>{contact.company}</td>
                             <td>{contact.email}</td>
-                            <td>{contact.phoneNumbers.map(phone => <span key={phone.number} className="contact-phone-number">{phone.type}: {phone.number}<br></br></span>)}</td>
+                            <td>
+                                {/* Iterate through each phone number and type */}
+                                {contact.phoneNumbers.map((phone, index) => (
+                                    <span key={`${contact._id}-${index}`} className="contact-phone-number">
+                                        {phone.type}: {phone.number}<br />
+                                    </span>
+                                ))}
+                            </td>
                             <td>{contact.contactType}</td>
                             <td className="contact-action-buttons">
                                 <button onClick={() => onViewClick(contact)}>View</button>

--- a/tracker-ui/src/components/ContactComponents/DeleteContactModal.js
+++ b/tracker-ui/src/components/ContactComponents/DeleteContactModal.js
@@ -1,20 +1,82 @@
+import React, { useState } from 'react';
+
 // Modal to confirm deletion of a contact
-const DeleteContactModal = ({ show, onClose, confirmDeletion }) => {
+const DeleteContactModal = ({ show, onClose, contact, deleteContact, contacts, setContacts }) => {
+
+    // For toggling the success message
+    const [showSuccess, setShowSuccess] = useState(false);
+
+    // For storing the original name to display
+    const [originalName, setOriginalName] = useState("");
+
+    // Handle the deletion
+    const handleSubmit = async (e) => {
+        // Prevent default action
+        e.preventDefault();
+        // Try to delete the contact
+        try {
+            // Get the contact _id
+            const contactId = contact._id;
+            // Set the original name to display
+            setOriginalName(contact.name)
+            // Delete the contact and await the response from deleteContact()
+            const deletedResponse = await deleteContact(contactId);
+            // If successful deletion
+            if (deletedResponse.message === 'Contact deleted') {
+                // Remove deleted contact from contacts
+                setContacts(contacts => contacts.filter(contact => contact._id !== contactId));
+                // Show the success message
+                setShowSuccess(true);
+                // Set timeout to close the success message, reset the original name, close the modal
+                setTimeout(() => {
+                    setShowSuccess(false);
+                    setOriginalName("");
+                    onClose();
+                }, 1500)
+            }
+            else {
+                // Log if error
+                console.log(deletedResponse.message)
+            }
+        } catch (error) {
+            // Catch and log the error
+            console.log("Failed to delete contact:", error);
+            alert("Failed to delete contact");
+        }
+    }
 
     // Return null if not displaying
     if (!show) return null;
 
     return (
+        // MODAL START
         <div className="delete-contact-modal">
+            {/* MODAL CONTENT START */}
             <div className="delete-contact-modal-content">
-                <div className="delete-contact-modal-body">
-                    <p>Are you sure you want to delete this contact?</p>
-                </div>
-                <div className="delete-contact-modal-footer">
-                    <button className="delete-contact-modal-delete-button" onClick={confirmDeletion}>Delete</button>
-                    <button className="delete-contact-modal-cancel-button" onClick={onClose}>Cancel</button>
-                </div>
+                {/* Display success message when user deletes contact, else display buttons to delete contact */}
+                {showSuccess ? (
+                    <>
+                        {/* Display the success message */}
+                        <div className="contact-form-success-message">
+                            <p>{originalName} has been deleted!</p>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        {/* Display buttons to delete or cancel */}
+                        <div className="delete-contact-modal-body">
+                            <p>Are you sure you want to delete:</p>
+                            <span className="delete-contact-modal-name-span">{contact.name}?</span>
+                        </div>
+                        <div className="delete-contact-modal-footer">
+                            <button className="delete-contact-modal-cancel-button" onClick={onClose}>Cancel</button>
+                            <button className="delete-contact-modal-delete-button" onClick={handleSubmit}>Delete</button>
+                        </div>
+                    </>
+                )}
+                {/* MODAL CONTENT END */}
             </div>
+            {/* MODAL END */}
         </div>
     );
 };

--- a/tracker-ui/src/components/ContactComponents/EditContactModal.js
+++ b/tracker-ui/src/components/ContactComponents/EditContactModal.js
@@ -1,86 +1,333 @@
 import React, { useState, useEffect } from 'react';
 
 // Modal to edit a contact
-const EditContactModal = ({ show, onClose, contact, updateContact }) => {
+const EditContactModal = ({ show, onClose, contact, updateContact, contacts, setContacts }) => {
 
     // Store edited contact
     const [editedContact, setEditedContact] = useState(contact);
 
-    // Set edited contact
+    // For toggling the success message
+    const [showSuccess, setShowSuccess] = useState(false);
+
+    // For checking if contact name already exists
+    const [nameExists, setNameExists] = useState(false);
+
+    // For storing original contact name
+    const [originalName, setOriginalName] = useState(editedContact?.name);
+
+    // Initialize edited contact with contact data
     useEffect(() => {
+        setOriginalName(contact.name);
         setEditedContact(contact);
     }, [contact]);
 
     // Handle event change
     const handleChange = (e) => {
-        const { name, value, type, checked } = e.target;
-        if (type === 'checkbox') {
-            setEditedContact({ ...editedContact, [name]: checked });
-        } else {
-            setEditedContact({ ...editedContact, [name]: value });
+        // Get event target details
+        const { name, value } = e.target;
+        // Edit the contact value (if strength of connection store as number)
+        setEditedContact(prevState => ({
+            ...prevState,
+            [name]: name === 'strengthOfConnection' ? Number(value) : value,
+        }));
+        // Check if name exists to warn user
+        if (name === 'name') {
+            const exists = checkForDuplicateName(value);
+            setNameExists(exists);
         }
     };
-    
+
     // Handle submission for edited contact
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
-        updateContact(editedContact);
-        onClose();
+        // Clone editedContact to avoid directly mutating state
+        let preparedEditedContact = { ...editedContact };
+        // Check and set dateAdded to today's date if it's blank or null
+        if (!preparedEditedContact.dateAdded) {
+            preparedEditedContact.dateAdded = new Date().toISOString().split('T')[0]; // Sets to YYYY-MM-DD format
+        }
+        // Check and remove temporary _id from phoneNumbers
+        if (preparedEditedContact.phoneNumbers && preparedEditedContact.phoneNumbers.length > 0) {
+            preparedEditedContact.phoneNumbers = preparedEditedContact.phoneNumbers.map(phoneNumber => {
+                if (phoneNumber._id && phoneNumber._id.startsWith('temp-')) { // Check for and remove temp _id
+                    const { _id, ...rest } = phoneNumber;
+                    return rest;
+                }
+                return phoneNumber;
+            });
+        }
+        try {
+            // Update contact with the prepared edited contact using the contact id and await updated contact
+            const updatedContact = await updateContact(preparedEditedContact, preparedEditedContact._id);
+            // Update the contacts state with the updated contact information
+            setContacts(prevContacts => {
+                return prevContacts.map(contact => contact._id === updatedContact._id ? updatedContact : contact);
+            });
+            // Show success modal
+            setShowSuccess(true);
+            // Set timeout to close success modal, reset if name exists, reset original name, close the modal
+            setTimeout(() => {
+                // Show success message, reset the form and close the modal
+                setShowSuccess(false);
+                setNameExists(false);
+                setOriginalName("");
+                setEditedContact({});
+                onClose();
+            }, 1500)
+        } catch (error) {
+            // Handle any errors that occur during the update
+            console.error("Failed to update contact:", error);
+            alert("Failed to update contact.");
+        }
     };
-    
+
+    // Handle phonenumber change in associated input field
+    const handlePhoneNumberChange = (_id, fieldName, value) => {
+        setEditedContact(prevState => {
+            const updatedPhoneNumbers = prevState.phoneNumbers.map(phoneNumber => {
+                if (phoneNumber._id === _id) {
+                    return { ...phoneNumber, [fieldName]: value };
+                }
+                return phoneNumber;
+            });
+            return { ...prevState, phoneNumbers: updatedPhoneNumbers };
+        });
+    };
+
+    // Handle adding the phone number
+    const handleAddPhoneNumber = () => {
+        setEditedContact(prevState => {
+            // Temporarily generate a unique ID for frontend purposes
+            const tempId = `temp-${Date.now()}`;
+            const newPhoneNumber = { number: '', type: 'Mobile', _id: tempId }; // Temporarily assign _id
+            return { ...prevState, phoneNumbers: [...prevState.phoneNumbers, newPhoneNumber] };
+        });
+    };
+
+
+    // Handle removing specific phone number
+    const handleRemovePhoneNumber = (_id) => {
+        setEditedContact(prevState => {
+            const updatedPhoneNumbers = prevState.phoneNumbers.filter(phoneNumber => phoneNumber._id !== _id);
+            return { ...prevState, phoneNumbers: updatedPhoneNumbers };
+        });
+    };
+
+    // Handle the check box change (referralPotential)
+    const handleCheckboxChange = (e) => {
+        const { name, checked } = e.target;
+        setEditedContact(prevState => ({
+            ...prevState,
+            [name]: checked
+        }));
+    };
+
+    // Text for strength of connection ratings
+    const ratingText = {
+        1: "1 - Very Low",
+        2: "2 - Low",
+        3: "3 - Moderate",
+        4: "4 - High",
+        5: "5 - Very High",
+    };
+
+    // Check for duplidate name (excluding the current contact name being edited)
+    const checkForDuplicateName = (value) => {
+        const nameToLower = value.toLowerCase();
+        const isDuplicate = contacts.some(contact =>
+            contact.name.toLowerCase() === nameToLower && contact.name.toLowerCase() !== originalName.toLowerCase()
+        );
+        // return true/false if duplicate
+        return isDuplicate;
+    };
+
+    // Allowable database fields (to dynamically generate options)
+    const contactTypes = ['Recruiter', 'Peer', 'Mentor', 'Alumni', 'Company Representative', 'Other'];
+    const interactionTypes = ['Email', 'LinkedIn', 'In-person', 'Phone call', 'Online event', 'Other'];
+    const sourceOfContacts = ['Job Fair', 'Referral', 'LinkedIn', 'Company Website', 'Networking Event', 'Other'];
+    const statusOfInteractions = ['Awaiting Response', 'In Discussion', 'Need to Follow Up', 'Closed', 'Other'];
+    const preferredContactMethods = ['Email', 'Phone', 'LinkedIn', 'Other'];
+    const phoneNumberTypes = ['Mobile', 'Work', 'Home', 'Other'];
+
     // Return null if not displaying
     if (!show) return null;
 
     return (
+        // MODAL START
         <div className="edit-contact-modal">
+            {/* MODAL CONTENT START */}
             <div className="edit-contact-modal-content">
-                <span className="edit-contact-modal-close-button" onClick={onClose}>&times;</span>
-                <form onSubmit={handleSubmit} className="edit-contact-modal-form">
-                    <div className="edit-contact-modal-form-row">
-                        <label htmlFor="name">Name</label>
-                        <input id="name" name="name" type="text" value={editedContact.name} onChange={handleChange} />
-                    </div>
+                {/* Display success message when user adds new contact, else display the form */}
+                {showSuccess ? (
+                    <>
+                        {/* Display the success message */}
+                        <div className="contact-form-success-message">
+                            <p>{editedContact.name} has been updated!</p>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <h2>{originalName}</h2>
+                        <span className="contact-form-modal-close" onClick={onClose}>&times;</span>
+                        {/* FORM START */}
+                        <form onSubmit={handleSubmit} className='contact-add-edit-view-form'>
 
-                    <div className="edit-contact-modal-form-row">
-                        <label htmlFor="company">Company</label>
-                        <input id="company" name="company" type="text" value={editedContact.company} onChange={handleChange} />
-                    </div>
+                            {/* Left hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-left-section">
+                                {/* Contact Name (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Name</label>
+                                <input type="text" name="name" onChange={handleChange} defaultValue={editedContact?.name || ""} className="contact-add-edit-view-form-input" maxLength="50" required />
+                                {nameExists && <span style={{ color: 'red', marginBottom: '10px' }}>Warning: this contact name already exists</span>}
+                                {/* Contact Company (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Company</label>
+                                <input type="text" name="company" onChange={handleChange} defaultValue={editedContact?.company || ""} className="contact-add-edit-view-form-input" maxLength="50" required />
+                                {/* Contact Email (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Email</label>
+                                <input type="email" name="email" onChange={handleChange} defaultValue={editedContact?.email || ""} className="contact-add-edit-view-form-input" maxLength="50" required />
+                                {/* Contact Phone Numbers (dynamic addition - up to 5 allowed numbers */}
+                                <label>Phone Numbers</label>
+                                {(editedContact.phoneNumbers || []).map((phoneNumber, index) => (
+                                    <div key={phoneNumber._id} className="contact-add-edit-view-form-phoneNumber-div">
+                                        <select name={`type-${phoneNumber._id}`} defaultValue={phoneNumber.type} onChange={(e) => handlePhoneNumberChange(phoneNumber._id, 'type', e.target.value)}>
+                                            {phoneNumberTypes.map(type => (
+                                                <option key={type} defaultValue={type}>{type}</option>
+                                            ))}
+                                        </select>
+                                        <input
+                                            type="text"
+                                            name={`number-${phoneNumber._id}`}
+                                            defaultValue={phoneNumber.number}
+                                            onChange={(e) => handlePhoneNumberChange(phoneNumber._id, 'number', e.target.value)}
+                                            placeholder="Phone Number"
+                                            maxLength={20}
+                                        />
+                                        {(editedContact.phoneNumbers.length > 1 || index === 0) && (
+                                            <button type="button" onClick={() => handleRemovePhoneNumber(phoneNumber._id)}>Remove</button>
+                                        )}
+                                    </div>
+                                ))}
+                                {/* Allow up to 5 phone numbers maximum */}
+                                {editedContact.phoneNumbers?.length < 5 && (
+                                    <button type="button" onClick={handleAddPhoneNumber}>Add Phone Number</button>
+                                )}
+                                {/* Contact Notes */}
+                                <label>Notes</label>
+                                <textarea name="notes" defaultValue={editedContact?.notes || ""} maxLength="200" className="contact-add-edit-view-form-notes-textarea" placeholder='Add your notes...' onChange={handleChange}></textarea>
+                            </div>
 
-                    <div className="edit-contact-modal-form-row">
-                        <label htmlFor="email">Email</label>
-                        <input id="email" name="email" type="email" value={editedContact.email} onChange={handleChange} />
-                    </div>
+                            {/* Right hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-right-section">
+                                {/* Container for all date inputs */}
+                                <div className="contact-add-edit-view-form-date-group">
+                                    {/* Contact Date Added */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Date Added</label>
+                                        <input type="date" name="dateAdded" defaultValue={editedContact?.dateAdded ? new Date(editedContact?.dateAdded).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" onChange={handleChange} />
+                                    </div>
+                                    {/* Contact Follow Up Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Follow Up Date</label>
+                                        <input type="date" name="followUpDate" defaultValue={editedContact?.followUpDate ? new Date(editedContact?.followUpDate).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" onChange={handleChange} />
+                                    </div>
+                                    {/* Contact Last Contacted Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Last Contacted Date</label>
+                                        <input type="date" name="lastContactedDate" defaultValue={editedContact?.lastContactedDate ? new Date(editedContact?.lastContactedDate).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" onChange={handleChange} />
+                                    </div>
+                                </div>
+                                {/* Contact Type (required) */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label htmlFor="contactType" className="contact-add-edit-view-form-required-input-label">Contact Type</label>
+                                    <select name="contactType" defaultValue={editedContact?.contactType || ""} className="contact-add-edit-view-form-select" required onChange={handleChange} >
+                                        <option defaultValue={editedContact?.contactType || ""}>{editedContact?.contactType || ""}</option>
+                                        {contactTypes.sort().map((type) => (
+                                            <option key={type} value={type}>{type}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Interaction Type */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Interaction Type</label>
+                                    <select name="interactionType" defaultValue={editedContact?.interactionType || ""} className="contact-add-edit-view-form-select" onChange={handleChange} >
+                                        <option defaultValue={editedContact?.interactionType || ""}>{editedContact?.interactionType || "Select Interaction Type"}</option>
+                                        {interactionTypes.sort().map((type) => (
+                                            <option key={type} value={type}>{type}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Source of Contact */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Source of Contact</label>
+                                    <select name="sourceOfContact" defaultValue={editedContact?.sourceOfContact || ""} className="contact-add-edit-view-form-select" onChange={handleChange} >
+                                        <option defaultValue={editedContact?.sourceOfContact || ""}>{editedContact?.sourceOfContact || "Select Source of Contact"}</option>
+                                        {sourceOfContacts.sort().map((source) => (
+                                            <option key={source} value={source}>{source}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Status of Interaction */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Status of Interaction</label>
+                                    <select name="statusOfInteraction" defaultValue={editedContact?.statusOfInteraction || ""} className="contact-add-edit-view-form-select" onChange={handleChange} >
+                                        <option defaultValue={editedContact?.statusOfInteraction || ""}>{editedContact?.statusOfInteraction || "Select Status Of Interaction"}</option>
+                                        {statusOfInteractions.sort().map((status) => (
+                                            <option key={status} value={status}>{status}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Preferred Contact Method */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Preferred Contact Method</label>
+                                    <select name="preferredContactMethod" defaultValue={editedContact?.preferredContactMethod || ""} className="contact-add-edit-view-form-select" onChange={handleChange} >
+                                        <option defaultValue={editedContact?.preferredContactMethod || ""}>{editedContact?.preferredContactMethod || "Select Preferred Contact Method"}</option>
+                                        {preferredContactMethods.sort().map((method) => (
+                                            <option key={method} value={method}>{method}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {/* Container for Strength of Connection and Referral Potential */}
+                                <div className="contact-add-edit-view-form-div-attributes-group">
+                                    {/* Strength of Connection */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Strength of Connection</label>
+                                        <input
+                                            type="range"
+                                            name="strengthOfConnection"
+                                            min="1"
+                                            max="5"
+                                            value={(editedContact?.strengthOfConnection || 1).toString()}
+                                            className="contact-add-edit-view-form-strength-of-connection-slider"
+                                            onChange={handleChange}
+                                        />
+                                        <div id="strengthDescription" className="contact-add-edit-view-form-strength-of-connection-description">
+                                            {ratingText[editedContact?.strengthOfConnection || 1]}
+                                        </div>
+                                    </div>
+                                    {/* Referral Potential */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Referral Potential</label>
+                                        <label className="contact-add-edit-view-form-label-referral-checkbox">
+                                            <input type="checkbox" name="referralPotential" checked={editedContact?.referralPotential || false} className='contact-add-edit-view-form-input-referral-checkbox' onChange={handleCheckboxChange} />
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
 
-                    {/* Assuming handling for multiple phone numbers is complex, here's a simplified approach for one */}
-                    <div className="edit-contact-modal-form-row">
-                        <label htmlFor="phoneNumber">Phone Number</label>
-                        <input
-                            id="phoneNumber"
-                            name="phoneNumber"
-                            type="tel"
-                            value={editedContact.phoneNumbers?.[0]?.number || ''}
-                            onChange={(e) => {
-                                // Ensure there's at least one phoneNumber object to work with
-                                const newPhoneNumbers = editedContact.phoneNumbers?.length > 0
-                                    ? [{ ...editedContact.phoneNumbers[0], number: e.target.value }]
-                                    : [{ number: e.target.value, type: 'Mobile' }];
-                                setEditedContact({ ...editedContact, phoneNumbers: newPhoneNumbers });
-                            }}
-                        />
-                    </div>
+                            {/* Form Footer for the buttons */}
+                            <div className="contact-add-edit-view-form-footer">
+                                {/* <button onClick={onClose}>Close</button> */}
+                                <span className='contact-add-edit-view-form-required-input-label'>* Required Information *</span>
+                                <div></div>
+                                <button type="submit" className="add-contact-form-clear-inputs-button">Save Changes</button>
+                            </div>
 
-                    {/* PLACEHOLDER - ADD ALL FIELDS */}
-                    <div className="under-construction-container">
-                        <span className="under-construction-text">🚧 More Fields To Be Added Soon</span>
-                    </div>
-                    {/* PLACEHOLDER END */}
-
-                    <div className="edit-contact-modal-form-actions">
-                        <button type="submit">Save Changes</button>
-                        <button type="button" onClick={onClose}>Cancel</button>
-                    </div>
-                </form>
+                            {/* FORM END */}
+                        </form>
+                    </>
+                )}
+                {/* MODAL CONTENT END */}
             </div>
+            {/* MODAL END */}
         </div>
     );
 };

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsCardBard.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsCardBard.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactsCard from '../ContactsCard';
+
+// Mock data for testing
+const mockContact = {
+    name: 'John Doe',
+    company: 'Awesome Inc.',
+    email: 'johndoe@awesome.com',
+};
+
+// Mock handlers for button clicks
+const onViewClickMock = jest.fn();
+const onEditClickMock = jest.fn();
+const onDeleteClickMock = jest.fn();
+
+describe('ContactsCard', () => {
+    // Basic rendering test
+    test('renders contact details correctly', () => {
+        render(<ContactsCard contact={mockContact} />);
+
+        expect(screen.getByText(mockContact.name)).toBeInTheDocument();
+        expect(screen.getByText(mockContact.company)).toBeInTheDocument();
+        expect(screen.getByText(mockContact.email)).toBeInTheDocument();
+    });
+
+    // Button click tests
+    test('calls onViewClick on View button click', () => {
+        render(<ContactsCard contact={mockContact} onViewClick={onViewClickMock} />);
+
+        fireEvent.click(screen.getByText('View'));
+
+        expect(onViewClickMock).toHaveBeenCalledWith(mockContact);
+    });
+
+    test('calls onEditClick on Edit button click', () => {
+        render(
+            <ContactsCard contact={mockContact} onEditClick={onEditClickMock} />
+        );
+
+        fireEvent.click(screen.getByText('Edit'));
+
+        expect(onEditClickMock).toHaveBeenCalledWith(mockContact);
+    });
+
+    test('calls onDeleteClick on Delete button click', () => {
+        render(
+            <ContactsCard contact={mockContact} onDeleteClick={onDeleteClickMock} />
+        );
+
+        fireEvent.click(screen.getByText('Delete'));
+
+        expect(onDeleteClickMock).toHaveBeenCalledWith(mockContact);
+    });
+
+    // Snapshot testing (optional)
+    test('matches snapshot', () => {
+        const { asFragment } = render(<ContactsCard contact={mockContact} />);
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsCardBing.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsCardBing.test.js
@@ -1,0 +1,99 @@
+// Import the necessary modules
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactsCard from '../ContactsCard';
+
+// Define some mock data and functions
+const mockContact = {
+    name: 'John Doe',
+    company: 'ABC Inc.',
+    email: 'john.doe@example.com'
+};
+
+const mockOnViewClick = jest.fn();
+const mockOnEditClick = jest.fn();
+const mockOnDeleteClick = jest.fn();
+
+// Describe the test suite
+describe('ContactsCard', () => {
+    // Test that the component renders correctly
+    test('renders contact card with name, company, email and actions', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsCard
+                contact={mockContact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Expect the contact details and actions to be in the document
+        expect(screen.getByText(mockContact.name)).toBeInTheDocument();
+        expect(screen.getByText(mockContact.company)).toBeInTheDocument();
+        expect(screen.getByText(mockContact.email)).toBeInTheDocument();
+        expect(screen.getByText('View')).toBeInTheDocument();
+        expect(screen.getByText('Edit')).toBeInTheDocument();
+        expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+
+    // Test that the onViewClick function is called when the View button is clicked
+    test('calls onViewClick when View button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsCard
+                contact={mockContact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the View button and click it
+        const viewButton = screen.getByText('View');
+        fireEvent.click(viewButton);
+
+        // Expect the onViewClick function to be called with the mock contact
+        expect(mockOnViewClick).toHaveBeenCalledWith(mockContact);
+    });
+
+    // Test that the onEditClick function is called when the Edit button is clicked
+    test('calls onEditClick when Edit button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsCard
+                contact={mockContact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the Edit button and click it
+        const editButton = screen.getByText('Edit');
+        fireEvent.click(editButton);
+
+        // Expect the onEditClick function to be called with the mock contact
+        expect(mockOnEditClick).toHaveBeenCalledWith(mockContact);
+    });
+
+    // Test that the onDeleteClick function is called when the Delete button is clicked
+    test('calls onDeleteClick when Delete button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsCard
+                contact={mockContact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the Delete button and click it
+        const deleteButton = screen.getByText('Delete');
+        fireEvent.click(deleteButton);
+
+        // Expect the onDeleteClick function to be called with the mock contact
+        expect(mockOnDeleteClick).toHaveBeenCalledWith(mockContact);
+    });
+});

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsCardGPT.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsCardGPT.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactsCard from '../ContactsCard';
+
+describe('ContactsCard', () => {
+    // Mock contact data
+    const contact = {
+        name: 'John Doe',
+        company: 'Doe Enterprises',
+        email: 'john@doe.com'
+    };
+
+    // Mock functions to simulate passing handlers
+    const mockOnViewClick = jest.fn();
+    const mockOnEditClick = jest.fn();
+    const mockOnDeleteClick = jest.fn();
+
+    test('displays contact information', () => {
+        render(
+            <ContactsCard
+                contact={contact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Assert that the contact information is displayed
+        expect(screen.getByText(contact.name)).toBeInTheDocument();
+        expect(screen.getByText(contact.company)).toBeInTheDocument();
+        expect(screen.getByText(contact.email)).toBeInTheDocument();
+    });
+
+    test('calls onViewClick when View button is clicked', () => {
+        render(
+            <ContactsCard
+                contact={contact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Simulate clicking the "View" button
+        fireEvent.click(screen.getByText('View'));
+        expect(mockOnViewClick).toHaveBeenCalledWith(contact);
+    });
+
+    test('calls onEditClick when Edit button is clicked', () => {
+        render(
+            <ContactsCard
+                contact={contact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Simulate clicking the "Edit" button
+        fireEvent.click(screen.getByText('Edit'));
+        expect(mockOnEditClick).toHaveBeenCalledWith(contact);
+    });
+
+    test('calls onDeleteClick when Delete button is clicked', () => {
+        render(
+            <ContactsCard
+                contact={contact}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Simulate clicking the "Delete" button
+        fireEvent.click(screen.getByText('Delete'));
+        expect(mockOnDeleteClick).toHaveBeenCalledWith(contact);
+    });
+});

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsTableBard.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsTableBard.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ContactsTable from '../ContactsTable';
+
+// Mock data for testing
+const mockContacts = [
+    {
+        _id: '1',
+        name: 'John Doe',
+        company: 'Awesome Inc.',
+        email: 'johndoe@awesome.com',
+        phoneNumbers: [{ type: 'mobile', number: '123-456-7890' }],
+        contactType: 'Client',
+    },
+    {
+        _id: '2',
+        name: 'Jane Smith',
+        company: 'Super Company',
+        email: 'janesmith@super.com',
+        phoneNumbers: [
+            { type: 'mobile', number: '987-654-3210' },
+            { type: 'work', number: '555-555-5555' },
+        ],
+        contactType: 'Vendor',
+    },
+];
+
+// Mock handlers for button clicks
+const onViewClickMock = jest.fn();
+
+describe('ContactsTable', () => {
+    // Basic rendering test
+    test('renders contacts table with headers and data', () => {
+        render(
+            <ContactsTable contacts={mockContacts} onViewClick={onViewClickMock} />
+        );
+
+        expect(screen.getByText('Contacts')).toBeInTheDocument();
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Company')).toBeInTheDocument();
+        expect(screen.getByText('Email')).toBeInTheDocument();
+        expect(screen.getByText('Phone')).toBeInTheDocument();
+        expect(screen.getByText('Contact Type')).toBeInTheDocument();
+        expect(screen.getAllByRole('row').length).toBe(3); // header + 2 contacts
+    });
+
+});

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsTableBing.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsTableBing.test.js
@@ -1,0 +1,144 @@
+// Import the necessary modules
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactsTable from '../ContactsTable';
+
+// Define some mock data and functions
+const mockContacts = [
+    {
+        _id: '1',
+        name: 'Alice Smith',
+        company: 'XYZ Ltd.',
+        email: 'alice.smith@example.com',
+        phoneNumbers: [
+            { type: 'Home', number: '111-1111' },
+            { type: 'Work', number: '222-2222' }
+        ],
+        contactType: 'Personal'
+    },
+    {
+        _id: '2',
+        name: 'Bob Jones',
+        company: 'ABC Inc.',
+        email: 'bob.jones@example.com',
+        phoneNumbers: [
+            { type: 'Mobile', number: '333-3333' }
+        ],
+        contactType: 'Business'
+    }
+];
+
+const mockOnViewClick = jest.fn();
+const mockOnEditClick = jest.fn();
+const mockOnDeleteClick = jest.fn();
+
+// Describe the test suite
+describe('ContactsTable', () => {
+    // Test that the component renders correctly
+    test('renders contacts table with headers, rows and actions', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsTable
+                contacts={mockContacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Expect the table headers to be in the document
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Company')).toBeInTheDocument();
+        expect(screen.getByText('Email')).toBeInTheDocument();
+        expect(screen.getByText('Phone')).toBeInTheDocument();
+        expect(screen.getByText('Contact Type')).toBeInTheDocument();
+
+        // Expect the table rows to be in the document
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+        expect(screen.getByText('XYZ Ltd.')).toBeInTheDocument();
+        expect(screen.getByText('alice.smith@example.com')).toBeInTheDocument();
+        expect(screen.getByText('Home: 111-1111')).toBeInTheDocument();
+        expect(screen.getByText('Work: 222-2222')).toBeInTheDocument();
+        expect(screen.getByText('Personal')).toBeInTheDocument();
+
+        expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+        expect(screen.getByText('ABC Inc.')).toBeInTheDocument();
+        expect(screen.getByText('bob.jones@example.com')).toBeInTheDocument();
+        expect(screen.getByText('Mobile: 333-3333')).toBeInTheDocument();
+        expect(screen.getByText('Business')).toBeInTheDocument();
+
+        // Expect the table actions to be in the document
+        expect(screen.getAllByText('View').length).toBe(2);
+        expect(screen.getAllByText('Edit').length).toBe(2);
+        expect(screen.getAllByText('Delete').length).toBe(2);
+    });
+
+    // Test that the onViewClick function is called when the View button is clicked
+    test('calls onViewClick when View button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsTable
+                contacts={mockContacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the View buttons and click them
+        const viewButtons = screen.getAllByText('View');
+        fireEvent.click(viewButtons[0]);
+        fireEvent.click(viewButtons[1]);
+
+        // Expect the onViewClick function to be called with the mock contacts
+        expect(mockOnViewClick).toHaveBeenCalledTimes(2);
+        expect(mockOnViewClick).toHaveBeenCalledWith(mockContacts[0]);
+        expect(mockOnViewClick).toHaveBeenCalledWith(mockContacts[1]);
+    });
+
+    // Test that the onEditClick function is called when the Edit button is clicked
+    test('calls onEditClick when Edit button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsTable
+                contacts={mockContacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the Edit buttons and click them
+        const editButtons = screen.getAllByText('Edit');
+        fireEvent.click(editButtons[0]);
+        fireEvent.click(editButtons[1]);
+
+        // Expect the onEditClick function to be called with the mock contacts
+        expect(mockOnEditClick).toHaveBeenCalledTimes(2);
+        expect(mockOnEditClick).toHaveBeenCalledWith(mockContacts[0]);
+        expect(mockOnEditClick).toHaveBeenCalledWith(mockContacts[1]);
+    });
+
+    // Test that the onDeleteClick function is called when the Delete button is clicked
+    test('calls onDeleteClick when Delete button is clicked', () => {
+        // Render the component with the mock data and functions
+        render(
+            <ContactsTable
+                contacts={mockContacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Find the Delete buttons and click them
+        const deleteButtons = screen.getAllByText('Delete');
+        fireEvent.click(deleteButtons[0]);
+        fireEvent.click(deleteButtons[1]);
+
+        // Expect the onDeleteClick function to be called with the mock contacts
+        expect(mockOnDeleteClick).toHaveBeenCalledTimes(2);
+        expect(mockOnDeleteClick).toHaveBeenCalledWith(mockContacts[0]);
+        expect(mockOnDeleteClick).toHaveBeenCalledWith(mockContacts[1]);
+    });
+});

--- a/tracker-ui/src/components/ContactComponents/Tests/ContactsTableGPT.test.js
+++ b/tracker-ui/src/components/ContactComponents/Tests/ContactsTableGPT.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactsTable from '../ContactsTable';
+
+// Mock data for contacts
+const contacts = [
+    {
+        _id: '1',
+        name: 'John Doe',
+        company: 'Doe Enterprises',
+        email: 'john@doe.com',
+        phoneNumbers: [{ type: 'Mobile', number: '123-456-7890' }],
+        contactType: 'Personal'
+    },
+];
+
+// Mock functions for click handlers
+const mockOnViewClick = jest.fn();
+const mockOnEditClick = jest.fn();
+const mockOnDeleteClick = jest.fn();
+
+describe('ContactsTable', () => {
+    beforeEach(() => {
+        // Clear all mocks before each test
+        mockOnViewClick.mockClear();
+        mockOnEditClick.mockClear();
+        mockOnDeleteClick.mockClear();
+    });
+
+    test('renders contact details for each contact', () => {
+        render(
+            <ContactsTable
+                contacts={contacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Check table headers
+        expect(screen.getByText('Name')).toBeInTheDocument();
+        expect(screen.getByText('Company')).toBeInTheDocument();
+        expect(screen.getByText('Email')).toBeInTheDocument();
+        expect(screen.getByText('Phone')).toBeInTheDocument();
+        expect(screen.getByText('Contact Type')).toBeInTheDocument();
+
+        // Check for contact details in the table
+        contacts.forEach(contact => {
+            expect(screen.getByText(contact.name)).toBeInTheDocument();
+            expect(screen.getByText(contact.company)).toBeInTheDocument();
+            expect(screen.getByText(contact.email)).toBeInTheDocument();
+            expect(screen.getByText(`${contact.phoneNumbers[0].type}: ${contact.phoneNumbers[0].number}`)).toBeInTheDocument();
+            expect(screen.getByText(contact.contactType)).toBeInTheDocument();
+        });
+    });
+
+    test('calls onViewClick when View button is clicked for a contact', () => {
+        render(
+            <ContactsTable
+                contacts={contacts}
+                onViewClick={mockOnViewClick}
+                onEditClick={mockOnEditClick}
+                onDeleteClick={mockOnDeleteClick}
+            />
+        );
+
+        // Simulate clicking the "View" button for the first contact
+        fireEvent.click(screen.getAllByText('View')[0]);
+        expect(mockOnViewClick).toHaveBeenCalledWith(contacts[0]);
+    });
+
+});

--- a/tracker-ui/src/components/ContactComponents/ViewContactModal.js
+++ b/tracker-ui/src/components/ContactComponents/ViewContactModal.js
@@ -1,20 +1,166 @@
+import React, { useState } from 'react';
+
 // Modal to view a contact
 const ViewContactModal = ({ show, onClose, contact }) => {
+
+    // For toggling between detail and summary views
+    const [showDetail, setShowDetail] = useState(false);
+
+    // Handle toggling the view
+    const handleView = (e) => {
+        e.preventDefault();
+        // Toggle between detail and summary
+        showDetail ? setShowDetail(false) : setShowDetail(true);
+    }
+
+    // Text for strength of connection ratings
+    const ratingText = {
+        1: "1 - Very Low",
+        2: "2 - Low",
+        3: "3 - Moderate",
+        4: "4 - High",
+        5: "5 - Very High",
+    };
 
     // Return null if not displaying
     if (!show) return null;
 
     return (
+        // MODAL START
         <div className="view-contact-modal">
+            {/* MODAL CONTENT START */}
             <div className="view-contact-modal-content">
-                <span className="view-contact-modal-close" onClick={onClose}>&times;</span>
-                <h3>Contact Details</h3>
-                <p><strong>Name:</strong> {contact.name}</p>
-                <p><strong>Company:</strong> {contact.company}</p>
-                <p><strong>Email:</strong> {contact.email}</p>
-                <div className="view-contact-modal-footer">
-                    <button onClick={onClose}>Close</button>
-                </div>
+                {/* Close Modal Button */}
+                <span className="contact-form-modal-close" onClick={onClose}>&times;</span>
+                <h2>{contact.name}</h2>
+                {/* Display summary view or detailed view */}
+                {!showDetail ? (
+                    <>
+                        {/* Display Summary */}
+                        <p><strong>Name:</strong> {contact.name}</p>
+                        <p><strong>Company:</strong> {contact.company}</p>
+                        <p><strong>Email:</strong> {contact.email}</p>
+                        <div className="contact-add-edit-view-form-footer">
+                            <div></div>
+                            <button className="view-contact-show-summary-detail-button" onClick={handleView}>Show Details</button>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        {/* FORM START (Display Detail) */}
+                        <form className='contact-add-edit-view-form'>
+
+                            {/* Left hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-left-section">
+                                {/* Contact Name (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Name</label>
+                                <input type="text" name="name" value={contact?.name || ""} className="contact-add-edit-view-form-input" required maxLength="50" readOnly />
+                                {/* Contact Company (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Company</label>
+                                <input type="text" name="company" value={contact?.company || ""} className="contact-add-edit-view-form-input" required maxLength="50" readOnly />
+                                {/* Contact Email (required) */}
+                                <label className='contact-add-edit-view-form-required-input-label'>Email</label>
+                                <input type="email" name="email" value={contact?.email || ""} className="contact-add-edit-view-form-input" required maxLength="50" readOnly />
+                                {/* Contact Phone Numbers (dynamic addition - up to 5 allowed numbers */}
+                                <label>{contact.phoneNumbers.length > 0 ? "Phone Numbers" : ""}</label>
+                                {contact.phoneNumbers.map((phoneNumber, index) => (
+                                    <div key={index} className="contact-add-edit-view-form-phoneNumber-div">
+                                        <select name={`type-${index}`} value={phoneNumber?.type || ""} disabled>
+                                            <option>{phoneNumber?.type || ""}</option>
+                                        </select>
+                                        <input type="text" name={`number-${index}`} value={phoneNumber?.number || ""} placeholder="Phone Number" maxLength={20} readOnly />
+                                    </div>
+                                ))}
+                                {/* Contact Notes */}
+                                <label>Notes</label>
+                                <textarea name="notes" value={contact?.notes || ""} maxLength="200" className="contact-add-edit-view-form-notes-textarea" placeholder='Add your notes...' readOnly></textarea>
+                            </div>
+
+                            {/* Right hand side input fields */}
+                            <div className="contact-add-edit-view-form-input-right-section">
+                                {/* Container for all date inputs */}
+                                <div className="contact-add-edit-view-form-date-group">
+                                    {/* Contact Date Added */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Date Added</label>
+                                        <input type="date" name="dateAdded" value={contact.dateAdded ? new Date(contact.dateAdded).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" readOnly />
+                                    </div>
+                                    {/* Contact Follow Up Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Follow Up Date</label>
+                                        <input type="date" name="followUpDate" value={contact.followUpDate ? new Date(contact.followUpDate).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" readOnly />
+                                    </div>
+                                    {/* Contact Last Contacted Date */}
+                                    <div className="contact-add-edit-view-form-date-input-div">
+                                        <label>Last Contacted Date</label>
+                                        <input type="date" name="lastContactedDate" value={contact.lastContactedDate ? new Date(contact.lastContactedDate).toISOString().split('T')[0] : ""} className="contact-add-edit-view-form-input" readOnly />
+                                    </div>
+                                </div>
+                                {/* Contact Type (required) */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label htmlFor="contactType" className="contact-add-edit-view-form-required-input-label">Contact Type</label>
+                                    <select name="contactType" value={contact?.contactType || ""} className="contact-add-edit-view-form-select" required disabled>
+                                        <option>{contact?.contactType || ""}</option>
+                                    </select>
+                                </div>
+                                {/* Interaction Type */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Interaction Type</label>
+                                    <select name="interactionType" value={contact?.interactionType || ""} className="contact-add-edit-view-form-select" disabled>
+                                        <option>{contact?.interactionType || ""}</option>
+                                    </select>
+                                </div>
+                                {/* Source of Contact */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Source of Contact</label>
+                                    <select name="sourceOfContact" value={contact?.sourceOfContact || ""} className="contact-add-edit-view-form-select" disabled>
+                                        <option>{contact?.sourceOfContact || ""}</option>
+                                    </select>
+                                </div>
+                                {/* Status of Interaction */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Status of Interaction</label>
+                                    <select name="statusOfInteraction" value={contact?.statusOfInteraction || ""} className="contact-add-edit-view-form-select" disabled>
+                                        <option>{contact?.statusOfInteraction || ""}</option>
+                                    </select>
+                                </div>
+                                {/* Preferred Contact Method */}
+                                <div className="contact-add-edit-view-form-div-select">
+                                    <label>Preferred Contact Method</label>
+                                    <select name="preferredContactMethod" value={contact?.preferredContactMethod || ""} className="contact-add-edit-view-form-select" disabled>
+                                        <option>{contact?.preferredContactMethod || ""}</option>
+                                    </select>
+                                </div>
+                                {/* Container for Strength of Connection and Referral Potential */}
+                                <div className="contact-add-edit-view-form-div-attributes-group">
+                                    {/* Strength of Connection */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Strength of Connection</label>
+                                        <input type="range" name="strengthOfConnection" min="1" max="5" value={contact.strengthOfConnection} className="contact-add-edit-view-form-strength-of-connection-slider" readOnly />
+                                        <div id="strengthDescription" className="contact-add-edit-view-form-strenght-of-connection-description">{ratingText[contact.strengthOfConnection]}</div>
+                                    </div>
+                                    {/* Referral Potential */}
+                                    <div className="contact-add-edit-view-form-div-attribute">
+                                        <label>Referral Potential</label>
+                                        <label className="contact-add-edit-view-form-label-referral-checkbox">
+                                            <input type="checkbox" name="referralPotential" checked={contact.referralPotential} className='contact-add-edit-view-form-input-referral-checkbox' readOnly />
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Form Footer for the buttons */}
+                            <div className="contact-add-edit-view-form-footer">
+                                <span className='contact-add-edit-view-form-required-input-label'>* Required Information *</span>
+                                <div></div>
+                                <button type="button" className="view-contact-show-summary-detail-button" onClick={handleView} >Show Summary</button>
+                            </div>
+
+                            {/* FORM END */}
+                        </form>
+                    </>
+
+                )}
             </div>
         </div>
     );

--- a/tracker-ui/src/pages/contacts/contacts.css
+++ b/tracker-ui/src/pages/contacts/contacts.css
@@ -10,7 +10,7 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), 0 10px 20px rgba(0, 0, 0, 0.2); 
   border-radius: 8px; 
   margin: 10px auto; 
-  width: 100%; 
+  width: 100vw; 
   max-width: 1200px; /* Ensures the div doesn't get too wide on larger screens */
   transition: transform 0.3s ease; 
 }
@@ -169,36 +169,16 @@
   color: black !important;
 }
 
-.theme-toggle-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0;
-  padding: 0;
-}
-
-/* Button styling */
-.theme-toggle-container button {
-  /* padding: 10px 20px; */
-  font-size: 16px;
-  font-weight: bold;
-  color: #FFF;
-  background-color: #007BFF;
-  border: none;
+.contacts-page-banner {
+  background-color: #f0f0f0;
+  padding: 1rem;
   border-radius: 5px;
-  cursor: pointer;
-  outline: none;
-  transition: background-color 0.3s, transform 0.2s;
+  margin-bottom: 1rem;
 }
 
-theme-toggle-container button:hover, theme-toggle-container button:focus {
-  background-color: #0056b3;
-  transform: scale(1.05);
-}
-
-theme-toggle-container button:active {
-  background-color: #00408b;
-  transform: scale(0.95);
+.contacts-page-banner-text {
+  text-align: center;
+  margin-bottom: 0.5rem;
 }
 
 .under-construction-container {
@@ -225,10 +205,12 @@ theme-toggle-container button:active {
 }
 
 
-/* STYLING FOR ADD CONTACT MODAL (BARD) */
+/* STYLING FOR ADD/EDIT/VIEW CONTACT MODALS (BARD) */
 
 /* Base modal styles */
-.add-contact-modal {
+.add-contact-modal,
+.edit-contact-modal,
+.view-contact-modal {
   position: fixed;
   top: 0;
   left: 0;
@@ -242,16 +224,18 @@ theme-toggle-container button:active {
 }
 
 /* Modal content styling */
-.add-contact-modal-content {
+.add-contact-modal-content,
+.edit-contact-modal-content,
+.view-contact-modal-content {
   background-color: #fff;
   padding: 40px;
   border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  width: 400px; /* Adjust as needed */
+  width: 75%; /* Adjust as needed */
 }
 
 /* Close button styling */
-.add-contact-modal-close {
+.contact-form-modal-close {
   position: absolute;
   top: 15px;
   right: 15px;
@@ -262,48 +246,313 @@ theme-toggle-container button:active {
 }
 
 /* Form styling */
-.add-contact-modal h2 {
-  margin-top: 0;
-  font-size: 24px;
-  font-weight: 500;
-  margin-bottom: 20px;
-  text-align: center; /* Center the heading */
+.contact-add-edit-view-form {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
 }
 
-.add-contact-modal label {
-  font-weight: bold;
-  font-size: 14px;
-  margin-bottom: 5px;
-  display: block;
+.contact-add-edit-view-form-input-left-section, .contact-add-edit-view-form-input-right-section {
+    display: flex;
+    flex-direction: column;
 }
 
-.add-contact-modal input {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 16px;
-  margin-bottom: 15px;
+/* Base styles for input fields */
+.contact-add-edit-view-form-input {
+    width: 100%; /* Full width to match the layout */
+    padding: 10px 15px; /* Adequate padding for text alignment and comfort */
+    border: 1px solid #ccc; /* Subtle border for a refined look */
+    border-radius: 5px; /* Rounded corners for a modern aesthetic */
+    font-size: 16px; 
+    line-height: 1.5; /* Line height for text input */
+    box-sizing: border-box; /* Include padding and border in the element's total dimensions */
+    background-color: #fff; /* Background color for visibility */
+    cursor: text; /* Cursor indication for text input */
+    transition: border-color 0.3s, box-shadow 0.3s; /* Smooth transition for focus and hover effects */
 }
 
-.add-contact-modal button[type="submit"] {
-  background-color: #007bff;
-  color: #fff;
-  border: none;
-  padding: 10px 15px;
-  border-radius: 4px;
+/* Hover effect for input fields */
+.contact-add-edit-view-form-input:hover {
+    border-color: #999; /* Darken border slightly on hover */
+}
+
+/* Focus effect for input fields */
+.contact-add-edit-view-form-input:focus {
+    outline: none; /* Remove default focus outline */
+    border-color: #007bff; /* Highlight with a stronger color on focus */
+    box-shadow: 0 0 0 2px rgba(0,123,255,.25); /* Soft glow effect */
+}
+
+/* Placeholder styling */
+::placeholder {
+    color: #aaa; /* Lighter text color for placeholders */
+}
+
+.contact-add-edit-view-form-phoneNumber-div {
+    display: flex;
+    gap: 10px;
+}
+
+.contact-add-edit-view-form-phoneNumber-div button {
+    margin-left: auto; /* Pushes the remove button to the right */
+}
+
+/* Styling for the textarea */
+.contact-add-edit-view-form-notes-textarea {
+    width: 100%; /* Full width to match the form layout */
+    height: 150px; /* Adequate height for entering notes */
+    padding: 15px; /* Comfortable padding for text entry */
+    border: 1px solid #ccc; /* Subtle border for a refined look */
+    border-radius: 8px; /* Rounded corners for a modern aesthetic */
+    font-size: 16px; /* Legible font size */
+    line-height: 1.5; /* Improve readability of multiline text */
+    box-sizing: border-box; /* Include padding and border in the total dimensions */
+    resize: vertical; /* Allow vertical resizing only */
+    background-color: #fafafa; /* Slightly off-white background for a soft look */
+    box-shadow: inset 0 1px 3px rgba(0,0,0,0.1); /* Inner shadow for depth */
+    transition: border-color 0.3s, box-shadow 0.3s; /* Smooth transition for focus effect */
+}
+
+/* Focus effect for textarea */
+.contact-add-edit-view-form-notes-textarea:focus {
+    outline: none; /* Remove the default focus outline */
+    border-color: #66afe9; /* Highlight border color on focus */
+    box-shadow: inset 0 1px 3px rgba(0,0,0,0.1), 0 0 8px rgba(102, 175, 233, 0.6); /* Enhanced focus with outer glow */
+}
+
+/* Placeholder styling for consistency */
+.contact-add-edit-view-form-notes-textarea::placeholder {
+    color: #aaa; /* Lighter color for the placeholder text */
+}
+
+.contact-add-edit-view-form-strength-of-connection-slider-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.contact-add-edit-view-form-strength-of-connection-slider-container input[type=range] {
+    flex-grow: 1;
+}
+
+.contact-add-edit-view-form-label-referral-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.contact-add-edit-view-form-footer {
+    grid-column: 1 / -1; /* Span the footer across both columns */
+    display: flex;
+    justify-content: space-between;
+}
+
+/* Ensure consistent box-sizing */
+.contact-add-edit-view-form-phoneNumber-div select,
+.contact-add-edit-view-form-phoneNumber-div input[type="text"],
+.contact-add-edit-view-form-phoneNumber-div button {
+    box-sizing: border-box; /* Ensure padding and border are included in the total height */
+}
+
+/* Uniform styling for select, input, and button */
+.contact-add-edit-view-form-phoneNumber-div select,
+.contact-add-edit-view-form-phoneNumber-div input[type="text"],
+.contact-add-edit-view-form-phoneNumber-div button {
+    height: 38px; /* Adjust based on actual match */
+    padding: 6px 12px; /* Adjust padding to match */
+    border: 1px solid #ccc; /* Match border styles */
+    border-radius: 4px; /* Optional: Adjust for rounded corners */
+    font-size: 16px; /* Adjust font size for alignment */
+}
+
+/* Additional alignment and styling adjustments */
+.contact-add-edit-view-form-phoneNumber-div select {
+    -webkit-appearance: none; /* Remove default styling for WebKit browsers */
+    -moz-appearance: none;    /* Remove default styling for Mozilla browsers */
+    appearance: none;         /* Standard way to remove default styling */
+    background-position: right 10px center; /* Adjust if using a custom arrow icon */
+    background-repeat: no-repeat;
+}
+
+.contact-add-edit-view-form-phoneNumber-div button {
+    padding: 0 12px; /* Adjust padding to ensure button text is centered */
+    background-color: #dc3545; /* Red */
+    color: white;
+    border-color: #dc3545; /* Adjust border color to match background */
+}
+
+.contact-add-edit-view-form-phoneNumber-div button:hover {
+    background-color: #c82333; /* Lighter red on hover */
+}
+
+/* Base styling for select dropdowns */
+.contact-add-edit-view-form-select {
+    margin-bottom: 15px;
+    width: 100%; /* Full width to match the layout */
+    padding: 10px 15px; /* Padding for comfort and alignment */
+    border: 1px solid #ccc; /* Subtle, refined border */
+    border-radius: 5px; /* Rounded corners for a modern look */
+    font-size: 16px; /* Readable text size */
+    line-height: 1.5; /* Adequate line height */
+    box-sizing: border-box; /* Include padding and border in the box model */
+    background-color: #fff; /* White background for visibility */
+    cursor: pointer; /* Indicate it's selectable */
+    appearance: none; /* Remove native appearance to customize */
+    -moz-appearance: none; /* For Firefox */
+    -webkit-appearance: none; /* For Chrome, Safari, and newer Edge */
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>'); /* Custom dropdown arrow */
+    background-repeat: no-repeat;
+    background-position: right 15px center; /* Position the arrow icon */
+    background-size: 20px 20px; /* Size of the arrow icon */
+}
+
+/* Focus and hover effects for select */
+.contact-add-edit-view-form-select:focus,
+.contact-add-edit-view-form-select:hover {
+    border-color: #999; /* Darker border for focus/hover */
+    outline: none; /* Remove focus outline */
+    box-shadow: 0 0 0 2px rgba(0,123,255,.25); /* Soft glow effect for focus */
+}
+
+/* For browsers that don't support `appearance` property */
+.contact-add-edit-view-form-select::-ms-expand {
+    display: none; /* Hide the default arrow in IE11 */
+}
+
+/* Base styling for the slider */
+.contact-add-edit-view-form-strength-of-connection-slider {
+    -webkit-appearance: none; /* Removes default webkit styles */
+    width: 100%; /* Full width to match the layout */
+    height: 8px; /* Height of the track */
+    background: #ddd; /* Background color of the track */
+    outline: none; /* Remove the outline on focus */
+    opacity: 0.7; /* Slightly transparent */
+    -webkit-transition: .2s; /* Transition for smooth color change */
+    transition: opacity .2s;
+    border-radius: 5px; /* Rounded corners for the track */
+}
+
+/* Hover effect for the slider */
+.contact-add-edit-view-form-strength-of-connection-slider:hover {
+    opacity: 1; /* Fully opaque on hover */
+}
+
+/* The slider handle (thumb) */
+.contact-add-edit-view-form-strength-of-connection-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; /* Removes default webkit styles */
+    appearance: none;
+    width: 20px; /* Width of the thumb */
+    height: 20px; /* Height of the thumb */
+    background: #007bff; /* Background color of the thumb */
+    cursor: pointer; /* Cursor on hover */
+    border-radius: 50%; /* Round shape */
+    border: 2px solid #fff; /* White border for the thumb */
+}
+
+.contact-add-edit-view-form-strength-of-connection-slider::-moz-range-thumb {
+    width: 20px; /* Width of the thumb */
+    height: 20px; /* Height of the thumb */
+    background: #007bff; /* Background color of the thumb */
+    cursor: pointer; /* Cursor on hover */
+    border-radius: 50%; /* Round shape */
+    border: 2px solid #fff; /* White border for the thumb */
+}
+
+/* Focus styles for the thumb */
+.contact-add-edit-view-form-strength-of-connection-slider:focus::-webkit-slider-thumb {
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.5); /* Focus indicator */
+}
+
+.contact-add-edit-view-form-strength-of-connection-slider:focus::-moz-range-thumb {
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.5); /* Focus indicator */
+}
+
+.contact-add-edit-view-form-input-referral-checkbox {
   cursor: pointer;
-  display: block; /* Full width button */
-  margin-top: 20px; /* Add some spacing */
+  height: 50px;
+}
+
+/* Styling when the checkbox is checked */
+.contact-add-edit-view-form-input-referral-checkbox:checked ~ .contact-checkbox-custom {
+    background-color: #007bff; /* Background color for checked state */
+    border-color: #007bff; /* Border color for checked state */
+}
+
+/* Show the checkmark icon when the checkbox is checked */
+.contact-add-edit-view-form-input-referral-checkbox:checked ~ .contact-checkbox-custom::after {
+    display: block;
+}
+
+/* Focus indicator for accessibility */
+.contact-add-edit-view-form-input-referral-checkbox:focus + .contact-checkbox-custom {
+    box-shadow: 0 0 0 2px rgba(0,123,255,.25);
+}
+
+.contact-add-edit-view-form-date-group {
+    display: flex;
+    justify-content: space-between; /* Distribute space evenly between the inputs */
+    gap: 10px; /* Provide some space between the inputs */
+}
+
+/* Optional: Adjustments for smaller screens */
+@media (max-width: 600px) {
+    .contact-add-edit-view-form-date-group {
+        flex-direction: column; /* Stack them vertically on small screens */
+        gap: 15px; /* Adjust gap for vertical stacking */
+    }
+}
+
+.contact-add-edit-view-form-div-attributes-group {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px; /* Adjust based on your design */
+    margin-top: 5%;
+    /* margin: 15%; */
+}
+
+.contact-add-edit-view-form-div-attribute {
+    display: flex;
+    flex-direction: column;
+    width: calc(50% - 10px); /* Adjust the width so both items can fit side by side */
+}
+
+.contact-add-edit-view-form-strenght-of-connection-description {
+    margin-top: 8px; 
+    text-align: center; 
+}
+
+.contact-add-edit-view-form-required-input-label {
+  color: blue;
+}
+
+.contact-add-edit-view-form-div-select {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px; /* Add some space between each field */
+}
+
+.contact-add-edit-view-form-div-select label, 
+.contact-add-edit-view-form-div-select select {
+    flex: 1; /* Each takes up half the space of the container */
+    margin-right: 5px; /* Add some space between the label and the select */
+}
+
+.contact-add-edit-view-form-div-select select {
+    margin-right: 0; /* Remove margin on the right side of the select */
 }
 
 /* Unique styling tricks */
-.add-contact-modal-content {
+.add-contact-modal-content,
+.edit-contact-modal-content,
+.view-contact-modal-content {
   position: relative; /* Enable positioning of pseudo-elements */
 }
 
 /* Create a subtle top border using a pseudo-element */
-.add-contact-modal-content::before {
+.add-contact-modal-content::before,
+.edit-contact-modal-content::before,
+.view-contact-modal-content::before {
   content: "";
   position: absolute;
   top: -10px;
@@ -312,6 +561,42 @@ theme-toggle-container button:active {
   height: 4px;
   background-color: #007bff; /* Match button color */
   border-radius: 10px 10px 0 0;
+}
+
+.contact-form-success-message {
+    /* Style for the success message */
+    color: #28a745;
+    text-align: center;
+}
+
+/* Adjustments for the Clear button */
+.add-contact-form-clear-inputs-button {
+    background-color: #ffc107; /* Yellow */
+    color: black;
+    border-color: #ffc107; /* Adjust border color to match background */
+}
+
+.add-contact-form-clear-inputs-button:hover {
+    background-color: #e0a800; /* Lighter yellow on hover */
+}
+
+/* Adjustments for the Clear button */
+.view-contact-form-close-button {
+    background-color: darkgray; /* Yellow */
+    color: black;
+    border-color: darkgray; /* Adjust border color to match background */
+}
+
+.view-contact-form-close-button:hover {
+    background-color: lightgray; /* Lighter yellow on hover */
+}
+
+.view-contact-show-summary-detail-button {
+  background-color: blue;
+}
+
+.view-contact-show-summary-detail-button:hover {
+  opacity: 85%;
 }
 
 /* STYLING FOR CONTACTS CARD (CHATGPT) */
@@ -461,7 +746,7 @@ theme-toggle-container button:active {
 }
 
 .contact-action-buttons button:nth-child(1) {
-    background-color: #4CAF50; /* View button */
+    background-color: blue; /* View button */
     color: white;
 }
 
@@ -538,11 +823,11 @@ theme-toggle-container button:active {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent backdrop */
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 100; /* Ensure modal is displayed above other content */
+  z-index: 100; 
 }
 
 /* Modal content styling */
@@ -551,7 +836,7 @@ theme-toggle-container button:active {
   padding: 30px;
   border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  width: 350px; /* Adjust as needed */
+  width: 350px;
 }
 
 /* Body content styling */
@@ -615,102 +900,8 @@ theme-toggle-container button:active {
   border-bottom: 20px solid #dc3545; /* Match delete button color */
 }
 
-/* STYLING FOR EDIT CONTACT MODAL (BARD) */
-
-/* Base modal styles */
-.edit-contact-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent backdrop */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100; /* Ensure modal is displayed above other content */
-}
-
-/* Modal content styling */
-.edit-contact-modal-content {
-  background-color: #fff;
-  padding: 40px;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  width: 450px; /* Adjust as needed */
-}
-
-/* Close button styling */
-.edit-contact-modal-close-button {
-  position: absolute;
-  top: 15px;
-  right: 15px;
-  font-size: 20px;
-  font-weight: bold;
-  color: #333;
-  cursor: pointer;
-}
-
-/* Form styling */
-.edit-contact-modal-form {
-  margin-top: 20px;
-}
-
-.edit-contact-modal-form-row {
-  margin-bottom: 15px;
-}
-
-.edit-contact-modal-form-row label {
-  font-weight: bold;
-  font-size: 14px;
-  margin-bottom: 5px;
-  display: block;
-}
-
-.edit-contact-modal-form-row input {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 16px;
-  color: #333;
-}
-
-.edit-contact-modal-form-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 20px;
-}
-
-.edit-contact-modal-form-actions button {
-  background-color: #54a0ff;
-  color: #fff;
-  border: none;
-  padding: 10px 15px;
-  border-radius: 4px;
-  cursor: pointer;
-  margin-left: 10px;
-}
-
-.edit-contact-modal-form-actions button:first-of-type {
-  background-color: #007bff; /* Differentiate primary action */
-}
-
-/* Unique styling tricks */
-.edit-contact-modal-content {
-  position: relative; /* Enable positioning of pseudo-elements */
-}
-
-/* Create a subtle top border using a pseudo-element */
-.edit-contact-modal-content::before {
-  content: "";
-  position: absolute;
-  top: -10px;
-  left: 0;
-  width: 100%;
-  height: 5px;
-  background-color: #54a0ff;
-  border-radius: 10px 10px 0 0;
+.delete-contact-modal-name-span {
+  color: red;
 }
 
 /* STYLING FOR SEARCH BAR (BING) */
@@ -746,87 +937,4 @@ theme-toggle-container button:active {
 
 .contact-search-bar input::placeholder {
     color: #666;
-}
-
-/* STYLING FOR VIEW CONTACT MODAL (BARD) */
-
-/* Base modal styles */
-.view-contact-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent backdrop */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100; /* Ensure modal is displayed above other content */
-}
-
-/* Modal content styling */
-.view-contact-modal-content {
-  background-color: #fff;
-  padding: 30px;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  width: 400px; /* Adjust as needed */
-}
-
-/* Close button styling */
-.view-contact-modal-close {
-  position: absolute;
-  top: 15px;
-  right: 15px;
-  font-size: 20px;
-  font-weight: bold;
-  color: #333;
-  cursor: pointer;
-}
-
-/* Content styling */
-.view-contact-modal-content h3 {
-  margin-top: 0;
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 15px;
-}
-
-.view-contact-modal-content p {
-  font-size: 15px;
-  color: #666;
-  margin-bottom: 10px;
-}
-
-/* Footer styling */
-.view-contact-modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 20px;
-}
-
-.view-contact-modal-footer button {
-  background-color: #54a0ff;
-  color: #fff;
-  border: none;
-  padding: 8px 15px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-/* Unique styling tricks */
-.view-contact-modal-content {
-  position: relative; /* Enable positioning of pseudo-elements */
-}
-
-/* Create a subtle top border using a pseudo-element */
-.view-contact-modal-content::before {
-  content: "";
-  position: absolute;
-  top: -10px;
-  left: 0;
-  width: 100%;
-  height: 3px;
-  background-color: #54a0ff;
-  border-radius: 10px 10px 0 0;
 }

--- a/tracker-ui/src/pages/contacts/contacts.js
+++ b/tracker-ui/src/pages/contacts/contacts.js
@@ -13,9 +13,6 @@ import ViewContactModal from '../../components/ContactComponents/ViewContactModa
 import ContactsMetrics from '../../components/ContactComponents/ContactsMetrics';
 import ContactsSearchBar from '../../components/ContactComponents/ContactsSearchBar';
 
-// Method to generate random contacts if none (FOR TESTING - DISCONNECT WHEN FRONTEND + BACKEND IMPLEMENTED)
-import generateRandomContacts from './generateRandomContacts';
-
 // Styling for the contacts page and components
 import './contacts.css';
 
@@ -30,9 +27,9 @@ const ContactsPage = () => {
     // Handle the toggle views
     const [viewMode, setViewMode] = useState('table'); // 'table', 'cards', or 'dashboard'
 
-    // Handle the search (not yet implemented)
+    // Handle the search
     const [searchQuery, setSearchQuery] = useState('');
-    
+
     // Handle contacts (i.e. users contacts)
     const [contacts, setContacts] = useState([]);
 
@@ -71,59 +68,118 @@ const ContactsPage = () => {
     };
 
     // Handler to get all contacts for the user
-    const handleGetContacts = () => {
-        const fetchContacts = async () => {
-            setIsLoading(true);
-            try {
-                const token = localStorage.getItem('token');
-                const response = await fetch('/contacts', {
-                    method: 'GET',
-                    headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Content-Type': 'application/json'
-                    }
-                });
-                if (!response.ok) {
-                    throw new Error('Network response was not ok');
+    const handleGetContacts = async () => {
+        // Set is loading as true
+        setIsLoading(true);
+        // Try to get all contacts with auth'd token
+        try {
+            const token = localStorage.getItem('token');
+            const response = await fetch('/contacts', {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
                 }
-                let data = await response.json();
-                // PLACEHOLDER - GENERATE RANDOM DUMMY CONTACTS IF USER HAS NONE
-                if (data.length === 0) {
-                    data = generateRandomContacts();
-                }
-                setContacts(data);
-            } catch (error) {
-                setError(error.message);
-            } finally {
-                setIsLoading(false);
+            });
+            // If response is not 200, throw an error
+            if (response.status !== 200) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            } else {
+                // Await all contacts data
+                const contactsData = await response.json();
+                // Set contacts data
+                setContacts(contactsData);
             }
-        };
-        fetchContacts();
+        } catch (error) {
+            // Catch the error
+            setError(error.message)
+        } finally {
+            // Set is loading as false
+            setIsLoading(false);
+        }
     }
 
-    // Handle saving/creating a new contact (not yet implemented)
-    const handleSaveContact = (contactData) => {
-        // PLACEHOLDER - connect to backed to add contact (fetch)
-        // PLACEHOLDER - On successful save, close modal & refresh page
-        console.log(contactData);
-        setShowAddModal(false);
+    // Handle creating a new contact
+    const handleCreateContact = async (newContact) => {
+        // Try to create the new contact with auth'd token
+        try {
+            const token = localStorage.getItem('token');
+            const response = await fetch('/contacts', {
+                method: 'POST',
+                body: JSON.stringify(newContact),
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
+            })
+            // If response is not 201, throw an error
+            if (response.status !== 201) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            } else {
+                // Await and returned the saved contact in db
+                const savedContact = await response.json();
+                return savedContact;
+            }
+        } catch (error) {
+            // Catch the error
+            setError(error.message)
+        }
     };
 
-    // Handle updating/editing contact (not yet implemented)
-    const handleUpdateContact = async (updatedContact) => {
-        // PLACEHOLDER - connect to backend to update contact (fetch)
-        // PLACEHOLDER - On successful update, update contacts state and close modal (refresh page)
-        setShowEditModal(false);
+    // Handle updating/editing contact
+    const handleUpdateContact = async (updatedContact, contactId) => {
+        // Try to update the contact with auth'd token
+        try {
+            const token = localStorage.getItem('token');
+            const response = await fetch(`/contacts/${contactId}`, {
+                method: 'PUT',
+                body: JSON.stringify(updatedContact),
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
+            })
+            // If response is not 200, throw an error
+            if (response.status !== 200) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            } else {
+                // Await and return the updated contact in db
+                const updatedContact = await response.json();
+                return updatedContact;
+            }
+        } catch (error) {
+            // Catch the error
+            setError(error.message)
+        }
     };
 
-    // Handle deleting/removing contact (not yet implemented)
-    const handleDeleteContact = async () => {
-        // PLACEHOLDER - connect to backend to delete contact (fetch)
-        // PLACEHOLDER - On successful deletion, remove contact from contacts state and close modal (refresh page)
-        setShowDeleteModal(false);
+    // Handle deleting/removing contact
+    const handleDeleteContact = async (contactId) => {
+        // Try to delete the contact with auth'd token
+        try {
+            const token = localStorage.getItem('token');
+            const response = await fetch(`/contacts/${contactId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
+            })
+            // If response is not 200, throw an error
+            if (response.status !== 200) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            } else {
+                // Await and return the deleted response from db
+                const deletedResponse = await response.json();
+                return deletedResponse
+            }
+        } catch (error) {
+            // Catch the error
+            setError(error.message)
+        }
     };
 
-    // Placeholder to handle search search handler (not yet implemented)
+    // Placeholder to handle search search handler
     const handleSearch = (query) => {
         setSearchQuery(query);
         console.log("Search query:", searchQuery);
@@ -137,6 +193,7 @@ const ContactsPage = () => {
         handleGetContacts();
     }, []);
 
+    // Toggle between light and dark mode
     const toggleTheme = () => {
         setTheme(theme === 'contacts-page-light-mode' ? 'contacts-page-dark-mode' : 'contacts-page-light-mode');
     };
@@ -180,7 +237,7 @@ const ContactsPage = () => {
 
     return (
         <>
-        <NavBar />
+            <NavBar />
             <div className={`${theme} contacts-page`}>
                 <div className="contacts-page-controls-container">
                     <button className="contacts-page-toggle-theme-button" onClick={toggleTheme}>{theme === 'contacts-page-light-mode' ? 'Light Mode is On' : 'Dark Mode Is On'}</button>
@@ -193,13 +250,55 @@ const ContactsPage = () => {
                         checked={viewMode === 'cards'} onChange={() => setViewMode(viewMode === 'table' ? 'cards' : 'table')} />
                     <label htmlFor="contacts-page-viewModeToggle" className="contacts-page-view-mode-label"></label>
                 </div>
-                {(viewMode === 'table' || viewMode === 'cards') && <ContactsSearchBar onSearch={handleSearch} />}
-                {renderView()}
+                {/* If no contacts then display message */}
+                {contacts.length === 0 ? (
+                    <>
+                        <div className="contacts-page-banner">
+                            <p className="contacts-page-banner-text">
+                                Looks like you don't have any contacts! Get started by adding new ones.
+                            </p>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        {/* Render the views for contacts */}
+                        {(viewMode === 'table' || viewMode === 'cards') && <ContactsSearchBar onSearch={handleSearch} />}
+                        {renderView()}
+                    </>
+                )}
             </div>
-            <AddContactModal show={showAddModal} onClose={() => setShowAddModal(false)} onSave={handleSaveContact}/>
-            {currentContact && <EditContactModal show={showEditModal} onClose={handleCloseModal} contact={currentContact} updateContact={handleUpdateContact} />}
-            {currentContact && <DeleteContactModal show={showDeleteModal} onClose={handleCloseModal} confirmDeletion={handleDeleteContact} />}
-            {currentContact && <ViewContactModal show={showViewModal} onClose={handleCloseModal} contact={currentContact}/>}
+            {/* Add Contact Modal */}
+            <AddContactModal
+                show={showAddModal}
+                onClose={handleCloseModal}
+                createContact={handleCreateContact}
+                contacts={contacts}
+                setContacts={setContacts}
+            />
+            {/* Edit Contact Modal for Current Contact */}
+            {currentContact && <EditContactModal
+                show={showEditModal}
+                onClose={handleCloseModal}
+                contact={currentContact}
+                updateContact={handleUpdateContact}
+                contacts={contacts}
+                setContacts={setContacts}
+            />}
+            {/* Delete Contact Modal for Current Contact */}
+            {currentContact && <DeleteContactModal
+                show={showDeleteModal}
+                onClose={handleCloseModal}
+                deleteContact={handleDeleteContact}
+                contact={currentContact}
+                contacts={contacts}
+                setContacts={setContacts}
+            />}
+            {/* View Contact Modal for Current Contact */}
+            {currentContact && <ViewContactModal
+                show={showViewModal}
+                onClose={handleCloseModal}
+                contact={currentContact}
+            />}
         </>
     );
 };


### PR DESCRIPTION
I used ChatGPT 4.0 to help piece together the Contact form inputs & connect the Contacts front/backend. Now all the db schema fields are in the UI forms. I've tested and everything seems to be working. I also did a Contacts className cleanup and consolidated to align and simplify modal forms for add/edit/view. I'm on track and will implement the other future planned tasks accordingly. In the future, I'll also try to make the company input show companies from the Jobs. 

Here's a summary of the changes:
- View all of a users contacts
- View a current/selected contact in summary & detail
- Create a new contact
- Update a contact
- Delete a contact
- Feedback notification of successful actions (timed div w/ message)

I also wanted to briefly explore the React testing library this week as I've never used it, so I included some basic tests from Bard/Bing/ChatGPT for simple Contacts components. You can run these in the tracker-ui folder with: **npm test** 

_(note: App.test.js has an old example test, but thought it would be helpful to leave for reference)._

**Example: Form w/ all db fields:**

![Screenshot 2024-02-10 at 9 14 28 AM](https://github.com/alesiram/cs467_capstone/assets/87046544/56582929-18f5-4237-9014-0b52e7fa0ea8)

**Example test output:**

![Screenshot 2024-02-10 at 9 17 10 AM](https://github.com/alesiram/cs467_capstone/assets/87046544/d04b1e2a-83b5-4e03-9dec-fc6937223fd8)