### PR TITLE
Contacts metrics

### DIFF
--- a/tracker-ui/src/components/ContactComponents/ContactsMetrics.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetrics.js
@@ -1,42 +1,31 @@
-// Dashboard metrics (PLACEHOLDER)
-const ContactsMetrics = () => {
+import ContactsMetricsPieChart from './ContactsMetricsPieChart';
+import ContactsMetricsFollowUps from './ContactsMetricsFollowUps';
+import ContactsMetricsStrengthReferral from './ContactsMetricsStrengthReferral';
+import ContactsMetricsTable from './ContactsMetricsTable';
+
+// Dashboard metrics
+const ContactsMetrics = ({ contacts }) => {
     return (
         <div className="contact-metrics-container">
+            {/* Display Pie Chart of Contact by Type */}
             <div className="contact-metric">
-                <h3>Total Contacts 👥</h3>
-                {/* PLACEHOLDER */}
-                <p></p>
-                <div className="under-construction-container">
-                    <span className="under-construction-text">🚧 Under Construction</span>
-                </div>
-                {/* PLACEHOLDER END */}
+                <h3>Contacts By Type</h3>
+                <ContactsMetricsPieChart data={contacts} />
             </div>
+            {/* Display List of Follow Up Dates */}
             <div className="contact-metric">
-                <h3>Metric 2 📈</h3>
-                {/* PLACEHOLDER */}
-                <p></p>
-                <div className="under-construction-container">
-                    <span className="under-construction-text">🚧 Under Construction</span>
-                </div>
-                {/* PLACEHOLDER END */}
+                <h3>Upcoming Follow Ups</h3>
+                <ContactsMetricsFollowUps contacts={contacts}/>
             </div>
+            {/* Display Breakdown of Strength of Connections & Referrals */}
             <div className="contact-metric">
-                <h3>Metric 3 📧</h3>
-                {/* PLACEHOLDER */}
-                <p></p>
-                <div className="under-construction-container">
-                    <span className="under-construction-text">🚧 Under Construction</span>
-                </div>
-                {/* PLACEHOLDER END */}
+                <h3>Strength & Referral Analysis</h3>
+                <ContactsMetricsStrengthReferral contacts={contacts}/>
             </div>
+            {/* Display Table Breakdown for Types/Methods */}
             <div className="contact-metric">
-                <h3>Metric 4 📞</h3>
-                {/* PLACEHOLDER */}
-                <p></p>
-                <div className="under-construction-container">
-                    <span className="under-construction-text">🚧 Under Construction</span>
-                </div>
-                {/* PLACEHOLDER END */}
+                <h3>Other Breakdowns</h3>
+                <ContactsMetricsTable contacts={contacts}/>
             </div>
         </div>
     );

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
@@ -1,28 +1,30 @@
 import React, { useState, useMemo } from 'react';
 
 // Pagination component to navigate through contacts in metric div
-const ContactsMetricsPagination = ({ itemsPerPage, totalItems, paginate }) => {
-    // Empty list to store page numbers
-    const pageNumbers = [];
-    // Determine the page numbers based on total items and items per page
-    for (let i = 1; i <= Math.ceil(totalItems / itemsPerPage); i++) {
-        pageNumbers.push(i);
+const ContactsMetricsPagination = ({ currentPage, itemsPerPage, totalItems, paginate }) => {
+    // If there are no items to show
+    if (totalItems === 0) {
+        return null;
     }
+    // Total Pages
+    const totalPages = Math.ceil(totalItems / itemsPerPage);
+    // Go to the next page
+    const goToNextPage = () => {
+        const nextPage = currentPage + 1;
+        if (nextPage <= totalPages) paginate(nextPage);
+    };
+    // Go to the previous page
+    const goToPreviousPage = () => {
+        const prevPage = currentPage - 1;
+        if (prevPage >= 1) paginate(prevPage);
+    };
     // Return the pagination navigation
     return (
         <nav className='contacts-metrics-pagination-nav'>
-            <ul className='contacts-metrics-pagination-list'>
-                {pageNumbers.map(number => (
-                    <li key={number} className='contacts-metrics-pagination-page-item'>
-                        <a href='#!' onClick={(e) => {
-                            e.preventDefault(); // Prevent the default anchor link behavior
-                            paginate(number);
-                        }}>
-                            {number}
-                        </a>
-                    </li>
-                ))}
-            </ul>
+            <button onClick={goToPreviousPage} disabled={currentPage === 1}>Back</button>
+            {/* Display current page and total pages */}
+            <span>Page {currentPage} of {totalPages}</span>
+            <button onClick={goToNextPage} disabled={currentPage === totalPages}>Forward</button>
         </nav>
     );
 };
@@ -79,7 +81,8 @@ const ContactsMetricsFollowUps = ({ contacts }) => {
                 // No Valid contacts so display message to user
                 <p className="contacts-metrics-no-followups-msg">No upcoming follow-ups. You're all caught up!</p>
             )}
-            <ContactsMetricsPagination 
+            <ContactsMetricsPagination
+                currentPage={currentPage}
                 itemsPerPage={contactsPerPage} 
                 totalItems={validContacts.length} 
                 paginate={paginate} 

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
@@ -45,6 +45,18 @@ const ContactsMetricsFollowUps = ({ contacts }) => {
     // Change page
     const paginate = pageNumber => setCurrentPage(pageNumber);
 
+    const formatDate = (dateString) => {
+        // Split the date string into its components
+        const [year, month, day] = dateString.split('-').map(num => parseInt(num, 10));
+
+        // Create a new date object using the local time zone
+        // Note: Months are 0-indexed in JavaScript Date objects, hence the `month - 1`
+        const date = new Date(year, month - 1, day);
+
+        // Format the date to a locale-specific date string without converting time zones
+        return date.toLocaleDateString();
+    }
+
     return (
         <div className="contacts-metrics-follow-up-reminders-div">
             {/* Display All Follow Up Dates if Valid Contacts */}
@@ -57,7 +69,7 @@ const ContactsMetricsFollowUps = ({ contacts }) => {
                             <li key={contact._id} className="contacts-metrics-follow-up-item">
                                 <p>{contact.name}</p>
                                 <p>{contact.email}</p>
-                                <p>{new Date(contact.followUpDate).toLocaleDateString()}</p>
+                                <p>{formatDate(contact.followUpDate)}</p>
                             </li>
                         ))}
                     </ul>

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps.js
@@ -1,0 +1,79 @@
+import React, { useState, useMemo } from 'react';
+
+// Pagination component to navigate through contacts in metric div
+const ContactsMetricsPagination = ({ itemsPerPage, totalItems, paginate }) => {
+    // Empty list to store page numbers
+    const pageNumbers = [];
+    // Determine the page numbers based on total items and items per page
+    for (let i = 1; i <= Math.ceil(totalItems / itemsPerPage); i++) {
+        pageNumbers.push(i);
+    }
+    // Return the pagination navigation
+    return (
+        <nav className='contacts-metrics-pagination-nav'>
+            <ul className='contacts-metrics-pagination-list'>
+                {pageNumbers.map(number => (
+                    <li key={number} className='contacts-metrics-pagination-page-item'>
+                        <a href='#!' onClick={(e) => {
+                            e.preventDefault(); // Prevent the default anchor link behavior
+                            paginate(number);
+                        }}>
+                            {number}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+};
+
+// Main component to display contacts and follow-up dates
+const ContactsMetricsFollowUps = ({ contacts }) => {
+
+    // States to manage the current page and the number of contacts per page
+    const [currentPage, setCurrentPage] = useState(1);
+    const [contactsPerPage] = useState(3);
+
+    // Filter contacts with valid followUpDate and sort by date
+    const validContacts = useMemo(() => contacts.filter(contact => contact.followUpDate).sort((a, b) => new Date(a.followUpDate) - new Date(b.followUpDate)), [contacts]);
+
+    // Get current contacts for pagination
+    const indexOfLastContact = currentPage * contactsPerPage;
+    const indexOfFirstContact = indexOfLastContact - contactsPerPage;
+    const currentContacts = validContacts.slice(indexOfFirstContact, indexOfLastContact);
+
+    // Change page
+    const paginate = pageNumber => setCurrentPage(pageNumber);
+
+    return (
+        <div className="contacts-metrics-follow-up-reminders-div">
+            {/* Display All Follow Up Dates if Valid Contacts */}
+            {validContacts.length > 0 ? (
+                <>
+                    <p className='contacts-metrics-current-date'>Today's Date: {new Date().toLocaleDateString()}</p>
+                    <ul className="contacts-metrics-follow-up-list">
+                        {/* For each contact display the name, email, follow up date */}
+                        {currentContacts.map(contact => (
+                            <li key={contact._id} className="contacts-metrics-follow-up-item">
+                                <p>{contact.name}</p>
+                                <p>{contact.email}</p>
+                                <p>{new Date(contact.followUpDate).toLocaleDateString()}</p>
+                            </li>
+                        ))}
+                    </ul>
+                    <br></br>
+                </>
+            ) : (
+                // No Valid contacts so display message to user
+                <p className="contacts-metrics-no-followups-msg">No upcoming follow-ups. You're all caught up!</p>
+            )}
+            <ContactsMetricsPagination 
+                itemsPerPage={contactsPerPage} 
+                totalItems={validContacts.length} 
+                paginate={paginate} 
+            />
+        </div>
+    );
+};
+
+export default ContactsMetricsFollowUps;

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsPieChart.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsPieChart.js
@@ -1,0 +1,153 @@
+import React, { useRef, useEffect, useState } from 'react';
+
+// Draw the pie chart with the context, chart data and canvas size
+const drawChart = (ctx, chartData, canvasSize) => {
+
+    // For sizing
+    const centerX = canvasSize / 2;
+    const centerY = canvasSize / 2;
+    const radius = canvasSize / 2 * 0.8; // 80% of half the canvas size
+
+    // Starting point on circle
+    let startAngle = 0;
+
+    // Total value for the chart (i.e. User's total contacts)
+    let totalValue = chartData.reduce((acc, item) => acc + item.value, 0);
+
+    // For each data point, draw the slice/fill labeling
+    chartData.forEach(data => {
+
+        // Calculate the slice and end angle
+        const sliceAngle = (2 * Math.PI * data.value) / totalValue;
+        const endAngle = startAngle + sliceAngle;
+
+        // Draw the slice
+        ctx.fillStyle = data.color;
+        ctx.beginPath();
+        ctx.moveTo(centerX, centerY);
+        ctx.arc(centerX, centerY, radius, startAngle, endAngle);
+        ctx.closePath();
+        ctx.fill();
+
+        // Calculate the percentage for the slice
+        const percentage = ((data.value / totalValue) * 100).toFixed(1); // Keep one decimal place
+
+        // Determine the position for the percentage text
+        const textX = centerX + radius / 2 * Math.cos(startAngle + sliceAngle / 2);
+        const textY = centerY + radius / 2 * Math.sin(startAngle + sliceAngle / 2);
+
+        // Set the style for the percentage text
+        ctx.fillStyle = "#FFFFFF"; // Use white for better visibility on primary/secondary colors
+        ctx.font = "bold 13px Arial"; // Make the font bold
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+
+        // Draw the percentage on the chart
+        ctx.fillText(`${percentage}%`, textX, textY);
+
+        // Move the start angle to draw next slice
+        startAngle += sliceAngle;
+    });
+};
+
+// Contacts metrics pie chart component
+const ContactsMetricsPieChart = ({ data }) => {
+
+    const canvasRef = useRef(null); // Initialize reference to null
+    const [isEmpty, setIsEmpty] = useState(false); // State to track if data is empty
+    const [legendData, setLegendData] = useState([]); // State to hold legend data
+
+
+    useEffect(() => {
+
+        // If no data
+        if (!data || !Array.isArray(data) || data.length === 0) {
+            setIsEmpty(true); // Set the isEmpty state to true if no data is available
+            return; // Exit the useEffect hook early
+        } else {
+            setIsEmpty(false); // Ensure isEmpty is false when there is data
+        }
+
+        // Reference to canvas element in DOM (i.e. attach the canvasRef to <canvas>)
+        const canvas = canvasRef.current;
+
+        // Render 2D context
+        if (canvas && canvas.parentNode) {
+
+            // Pie chart colors
+            const colors = [
+                '#FF0000', // Red
+                '#006400', // Dark Green
+                '#0000FF', // Blue
+                '#301934', // Dark Purple
+                '#FF00FF', // Magenta
+                '#000000', // Black
+            ];
+
+            // Get the canvas parent and the computed style for sizing
+            const parent = canvas.parentNode;
+            const parentComputedStyle = window.getComputedStyle(parent);
+            const parentWidth = parseFloat(parentComputedStyle.width);
+            const parentPadding = parseFloat(parentComputedStyle.paddingLeft) + parseFloat(parentComputedStyle.paddingRight);
+
+            // 350px or less to fit within padding
+            const size = Math.min(parentWidth - parentPadding, 350); 
+            canvas.style.width = `${size}px`;
+            canvas.style.height = `${size}px`;
+
+            // Adjust the drawing buffer size
+            const scale = window.devicePixelRatio;
+            canvas.width = size * scale;
+            canvas.height = size * scale;
+            const ctx = canvas.getContext('2d');
+            ctx.scale(scale, scale);
+
+            // Process data only if it's not empty
+            const distribution = data.reduce((acc, contact) => {
+                // Handle contacts without a 'contactType'
+                const type = contact.contactType || 'Unknown'; 
+                acc[type] = (acc[type] || 0) + 1;
+                return acc;
+            }, {});
+
+            // Create the data for the chart
+            const chartData = Object.keys(distribution).map((key, index) => ({
+                // Slice to show only partial text for category that is too long
+                label: `${key.slice(0,11)}: ${distribution[key]}`,
+                value: distribution[key],
+                color: colors[index % colors.length],
+            }));
+
+            // Set the legend data
+            setLegendData(chartData.map(item => ({ label: item.label, color: item.color })));
+
+            // Call method to draw chart with given context, chart data, and size
+            drawChart(ctx, chartData, size);
+        }
+    }, [data]); // Depend on data to re-run effect when it changes
+
+    return (
+        <div>
+            {/* If there is no contact data, then display a message instead */}
+            {isEmpty ? (
+                <div className="no-data-warning">No data available!</div>
+            ) : (
+                <>
+                    {/* Display Pie Chart & Legend */}
+                    <canvas className="contacts-metrics-pie-chart" ref={canvasRef} />
+                    <div className="contacts-metrics-pie-chart-legend">
+                        {legendData.map((item, index) => (
+                            <div key={index} className="contacts-metrics-pie-chart-legend-item">
+                                <span className="contacts-metrics-pie-chart-legend-color" style={{ backgroundColor: item.color }}></span>
+                                <span className="contacts-metrics-pie-chart-legend-label">{item.label}</span>
+                            </div>
+                        ))}
+                    </div>
+                </>
+
+            )}
+        </div>
+    );
+};
+
+export default ContactsMetricsPieChart;

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsStrengthReferral.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsStrengthReferral.js
@@ -1,0 +1,88 @@
+import React from 'react';
+
+// To display each strength (of connection) breakdown
+const StrengthMetricsBox = ({ level, totalContacts, referralPotential }) => {
+    
+    // Strength Description Ratings
+    const strengthDescriptions = {
+        '1': 'Very Low',
+        '2': 'Low',
+        '3': 'Moderate',
+        '4': 'High',
+        '5': 'Very High'
+    };
+    // Display level, total contacts at each level, and % of each that are referral potential
+    return (
+        <div className={`contacts-metrics-strength-box-div contacts-metrics-strength-${level}`}>
+            <div>
+                <p className={`contacts-strength-metrics-box-level`}>{level === "Total" ? "Total Contacts" : strengthDescriptions[level]}</p>
+                <p># Contacts: <span>{totalContacts}</span></p>
+                <p>Referral Potential: <span>{referralPotential}</span></p>
+            </div>
+        </div>
+    );
+};
+
+// Contacts metrics for strength of connection and referral potential
+const ContactsMetricsStrengthReferral = ({ contacts }) => {
+    
+    // Calculate the total number of contacts, and initialize the total referrals
+    const totalContacts = contacts.length;
+    let totalReferrals = 0;
+
+    // Initialize an object to store counts by strength level
+    const strengthLevels = {
+        1: { total: 0, referralPotential: 0 },
+        2: { total: 0, referralPotential: 0 },
+        3: { total: 0, referralPotential: 0 },
+        4: { total: 0, referralPotential: 0 },
+        5: { total: 0, referralPotential: 0 },
+    };
+
+    // Aggregate data from contacts
+    contacts.forEach(contact => {
+        if (strengthLevels[contact.strengthOfConnection]) {
+            strengthLevels[contact.strengthOfConnection].total += 1;
+            if (contact.referralPotential) {
+                strengthLevels[contact.strengthOfConnection].referralPotential += 1;
+                // increment the total count of referral potentials
+                totalReferrals += 1;
+            }
+        }
+    });
+
+    // Check if there are no contacts
+    if (totalContacts === 0) {
+        return <div>No contacts available.</div>;
+    }
+
+    return (
+        <>
+            {/* Display each strength of connection and the count/% for each */}
+            <div className="contacts-metrics-strength-referral-container">
+                {/* Display breakdown of total contacts */}
+                <StrengthMetricsBox 
+                    level={"Total"} 
+                    totalContacts={totalContacts}
+                    referralPotential={`${totalReferrals} (${totalReferrals > 0 ? ((totalReferrals / totalContacts) * 100).toFixed(2) : 0}%)`}
+                />
+                {/* Display breakdown of contacts by strength of connection */}
+                {Object.entries(strengthLevels).map(([level, { total, referralPotential }]) => {
+                    // Calc percentage of contacts with referral potential at each strength level
+                    const percentage = total > 0 ? ((referralPotential / total) * 100).toFixed(2) : 0;
+                    // Display each strength level breakdown
+                    return (
+                        <StrengthMetricsBox
+                            key={level}
+                            level={level}
+                            totalContacts={total}
+                            referralPotential={`${referralPotential} (${percentage}%)`}
+                        />
+                    );
+                })}
+            </div>
+        </>
+    );
+};
+
+export default ContactsMetricsStrengthReferral;

--- a/tracker-ui/src/components/ContactComponents/ContactsMetricsTable.js
+++ b/tracker-ui/src/components/ContactComponents/ContactsMetricsTable.js
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+
+// Contacts metrics for various types/categories
+const ContactsMetricsTable = ({ contacts }) => {
+
+    // State to keep track of the current active table
+    const [activeTable, setActiveTable] = useState('interactionType');
+
+    // Function to format header text
+    const formatHeaderText = (text) => {
+        return text
+            // Split based on uppercase letters
+            .split(/(?=[A-Z])/)
+            // Capitalize the first letter of each word and join with spaces
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+    };
+
+    // Function to calculate counts and percentages for the active table
+    const calculateData = () => {
+
+        // Initiliaze variables
+        const dataMap = {};
+        let total = 0;
+
+        // Calc for each contact
+        contacts.forEach(contact => {
+            const key = contact[activeTable];
+            if (key) { // Ensure key is not null
+                if (dataMap[key]) {
+                    dataMap[key].count += 1;
+                } else {
+                    dataMap[key] = { count: 1 };
+                }
+                total += 1;
+            }
+        });
+
+        // Calculate percentage
+        Object.keys(dataMap).forEach(key => {
+            dataMap[key].percentage = (dataMap[key].count / total * 100).toFixed(2);
+        });
+
+        // Return the map and total
+        return { dataMap, total };
+    };
+
+    // Calculate the data for the current active table
+    const { dataMap, total } = calculateData();
+
+    return (
+        <div className='contacts-metrics-table-component-container'>
+            <div className='contacts-metrics-table-toggle-buttons-container'>
+                <div className="contacts-metrics-table-toggle-buttons-div">
+                    {/* Buttons to toggle the active table */}
+                    <button onClick={() => setActiveTable('interactionType')}>Interaction Type</button>
+                    <button onClick={() => setActiveTable('sourceOfContact')}>Source of Contact</button>
+                    <button onClick={() => setActiveTable('statusOfInteraction')}>Status of Interaction</button>
+                    <button onClick={() => setActiveTable('preferredContactMethod')}>Preferred Contact Method</button>
+                </div>
+            </div>
+            {/* Show message if no data available for the active category */}
+            {total === 0 ? (
+                <div>No data available for {formatHeaderText(activeTable)}.</div>
+            ) : (
+                <>
+                    <div className='contacts-metrics-table-container'>
+                        <table className='contacts-metrics-table'>
+                            <thead>
+                                <tr>
+                                    <th>{formatHeaderText(activeTable)}</th>
+                                    <th># Contacts</th>
+                                    <th>% of Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {/* Map the data to table rows */}
+                                {Object.entries(dataMap).map(([key, value]) => (
+                                    <tr key={key}>
+                                        <td>{key}</td>
+                                        <td>{value.count}</td>
+                                        <td>{value.percentage}%</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default ContactsMetricsTable;

--- a/tracker-ui/src/pages/contacts/contacts.css
+++ b/tracker-ui/src/pages/contacts/contacts.css
@@ -6,18 +6,6 @@
   align-items: center;
   padding: 20px;
   min-height: 100vh; /* Ensure full-height layout */
-  background-color: #ffffff; 
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), 0 10px 20px rgba(0, 0, 0, 0.2); 
-  border-radius: 8px; 
-  margin: 10px auto; 
-  width: 100vw; 
-  max-width: 1200px; /* Ensures the div doesn't get too wide on larger screens */
-  transition: transform 0.3s ease; 
-}
-
-.contacts-page:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1), 0 15px 25px rgba(0, 0, 0, 0.2);
 }
 
 /* Controls container styling */
@@ -772,7 +760,7 @@
     }
 }
 
-/* STYLING FOR DASHBOARD METRICS (BING) */
+/* STYLING FOR DASHBOARD METRICS (BING + ChatGPT) */
 
 .contact-metrics-container {
     display: flex;
@@ -785,34 +773,290 @@
 }
 
 .contact-metric {
-    width: 250px;
-    height: 150px;
+    width: 400px; /* Adjusted to fit the canvas */
+    height: 450px; /* Increased height to accommodate title and canvas */
     border: 1px solid #ccc;
     border-radius: 10px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around; /* Align items to start to keep the title at the top */
     overflow: hidden;
+    position: relative; /* For potential absolute positioning inside */
+    padding-top: 40px; /* Added padding to avoid title overlap */
+    padding: 20px; /* Ensure padding for inner content */
+    background-color: #fff;
 }
 
 .contact-metric:hover {
     transform: scale(1.05);
-    transition: all 0.3s;
+    transition: all 0.3s ease-in-out;
 }
 
 .contact-metric h3 {
+    position: absolute; /* Make the title stick to the top */
+    top: 0;
+    width: 100%;
     margin: 0;
     padding: 10px;
     background: linear-gradient(to right, #f0f0f0, #e6e6e6);
+    text-align: center; /* Ensure title is centered */
+    color: #007bff; 
+    margin-bottom: 15px; /* Space between title and details */
+}
+
+.contacts-metrics-pie-chart {
+    width: auto; /* Make canvas responsive */
+    height: auto; /* Adjust height automatically */
+    max-width: 350px; /* Limit max width to fit inside .contact-metric */
+    aspect-ratio: 1 / 1; /* Maintain a square aspect ratio */
+}
+
+.contacts-metrics-pie-chart:hover {
+  transform: scale(1.05);
+  transition: all 0.1s ease-in-out;
+  cursor: pointer;
+}
+
+.contacts-metrics-pie-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.contacts-metrics-pie-chart-legend-item {
+  display: flex;
+  align-items: center;
+  margin: 10px;
+  padding: 2px;
+}
+
+.contacts-metrics-pie-chart-legend-item:hover {
+  transform: scale(1.05);
+  transition: all 0.1s ease-in-out;
+  color: red;
+  cursor: pointer;
+}
+
+.contacts-metrics-pie-chart-legend-color {
+  width: 20px;
+  height: 20px;
+  display: block;
+  border-radius: 50%;
+  margin-right: 5px;
+}
+
+.contacts-metrics-pie-chart-legend-label {
+  font-size: 14px;
+}
+
+.contacts-metrics-follow-up-reminders-div {
+  margin: 0; /* Remove margins to fit within the contact-metric padding */
+  width: 100%;
+}
+
+/* List and Item Styles */
+.contacts-metrics-follow-up-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto; /* Allow scrolling within the list */
+    max-height: 300px; 
+    width: 100%; /* Use the full width of the parent */
+}
+
+.contacts-metrics-follow-up-item {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #eee; /* Slightly more defined border */
+  border-radius: 8px; /* Rounded corners for a softer look */
+  padding: 15px; /* Increased padding for more space around the content */
+  margin-bottom: 10px; /* Space between items */
+  background-color: #fff; /* Base background to stand out against a potential container bg */
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1); /* Subtle shadow for depth */
+  transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth transitions for hover effects */
+  align-items: center; /* Align items for a cleaner look */
+  justify-content: space-between; /* Space content nicely */
+}
+
+.contacts-metrics-follow-up-item:hover {
+  background-color: #f7f7f7;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  cursor: pointer;
+  background-color: grey;
+  color: white;
+}
+
+.contacts-metrics-current-date {
+  margin-top: 15%;
+  color: #0056b3;
+  font-weight: bold;
+}
+
+.contacts-metrics-pagination-nav {
+  background-color: lightgray;
+}
+
+.contacts-metrics-follow-up-reminders-div {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between; /* Distributes space between content and pagination */
+    height: 100%; /* Fill the parent container */
+}
+
+/* Pagination Styles */
+.contacts-metrics-pagination-list {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    width: 100%; /* Ensure full width within the container */
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px; /* Space from the list to the pagination */
+}
+
+.contacts-metrics-no-followups-msg {
+  margin-top: 15%;
+}
+
+.contacts-metrics-pagination-page-item a {
+    border: 1px solid black;
+    border-radius: 5px;
+    padding: 5px 10px;
+    color: white;
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+    background-color: black;
+}
+
+.contacts-metrics-pagination-page-item a:hover {
+    background-color: white;
+    border-color: white;
+    color: black;
+}
+
+.contacts-metrics-strength-referral-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    padding: 20px;
+    justify-content: center;
+    align-items: start;
+    margin-top: 15%;
+
+}
+
+.contacts-metrics-strength-box-div {
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    margin: 10px;
+    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 5px;
+}
+
+/* Color coding for strength levels */
+.contacts-metrics-strength-1 { background-color: #FFC1C1; } /* Very Low - Red */
+.contacts-metrics-strength-2 { background-color: #FFDCA2; } /* Low - Lighter Red/Orange */
+.contacts-metrics-strength-3 { background-color: #FFFACD; } /* Moderate - Yellow */
+.contacts-metrics-strength-4 { background-color: #BFDCAE; } /* High - Light Green */
+.contacts-metrics-strength-5 { background-color: #90EE90; } /* Very High - Green */
+
+.contacts-metrics-strength-box-div:hover {
+    transform: translateY(-5px);
+    cursor: pointer;
+}
+
+.contacts-metrics-strength-box-div p {
+    margin: 5px 0;
+    font-size: 16px;
     color: #333;
 }
 
-.contact-metric p {
-    margin: 0;
-    padding: 10px;
-    display: grid;
-    place-items: center;
-    font-size: 2em;
-    color: #666;
+.contacts-metrics-strength-box-div span {
+    font-weight: bold;
 }
+
+.contacts-strength-metrics-box-level {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+/* Adjust button size and grid */
+.contacts-metrics-table-toggle-buttons-div {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* 2 buttons per row */
+  gap: 10px; /* Space between buttons */
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+.contacts-metrics-table-toggle-buttons-div button {
+  padding: 5px 10px; /* Reduce padding for smaller buttons */
+  font-size: 0.8rem; /* Smaller font size */
+  border: none;
+  border-radius: 5px;
+  background-color: black;
+  color: white;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.contacts-metrics-table-toggle-buttons-div button:hover {
+  background-color: #0056b3;
+}
+
+.contacts-metrics-table-toggle-buttons-div button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0,123,255,.25);
+}
+
+/* Container for the entire ContactsTable component */
+.contacts-metrics-table-component-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%; /* Use the full height of the parent .contact-metric */
+}
+
+/* Container for the toggle buttons */
+.contacts-metrics-table-toggle-buttons-container {
+  margin-bottom: 10px; /* Space between buttons and table */
+  margin-top: 15%;
+}
+
+/* Scrollable container for the table */
+.contacts-metrics-table-container {
+  overflow-y: auto; /* Enable vertical scrolling */
+  flex-grow: 1; /* Allow the table container to expand and fill available space */
+}
+
+/* Update for table to fit within .contact-metric */
+.contacts-metrics-table {
+  width: 100%;
+  max-height: 200px; 
+  overflow-y: auto; /* Allow scrolling within the table */
+  border-collapse: collapse;
+  font-size: 0.9rem; /* Adjust font size for space */
+}
+
+.contacts-metrics-table th,
+.contacts-metrics-table td {
+  padding: 8px;
+  text-align: center;
+}
+
+.contacts-metrics-table th {
+  background-color: darkgray;
+  color: white;
+}
+
+.contacts-metrics-table tr:nth-child(even) {background-color: #f2f2f2;}
+.contacts-metrics-table tr:hover {background-color: #ddd;}
 
 /* STYLING FOR DELETE CONTACT MODAL (BARD) */
 

--- a/tracker-ui/src/pages/contacts/contacts.css
+++ b/tracker-ui/src/pages/contacts/contacts.css
@@ -906,35 +906,8 @@
     height: 100%; /* Fill the parent container */
 }
 
-/* Pagination Styles */
-.contacts-metrics-pagination-list {
-    display: flex;
-    list-style: none;
-    padding: 0;
-    width: 100%; /* Ensure full width within the container */
-    justify-content: center;
-    gap: 10px;
-    margin-top: 20px; /* Space from the list to the pagination */
-}
-
 .contacts-metrics-no-followups-msg {
   margin-top: 15%;
-}
-
-.contacts-metrics-pagination-page-item a {
-    border: 1px solid black;
-    border-radius: 5px;
-    padding: 5px 10px;
-    color: white;
-    text-decoration: none;
-    transition: all 0.2s ease-in-out;
-    background-color: black;
-}
-
-.contacts-metrics-pagination-page-item a:hover {
-    background-color: white;
-    border-color: white;
-    color: black;
 }
 
 .contacts-metrics-strength-referral-container {

--- a/tracker-ui/src/pages/contacts/contacts.js
+++ b/tracker-ui/src/pages/contacts/contacts.js
@@ -22,7 +22,6 @@ const ContactsPage = () => {
     // Handle when screen is loading
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [theme, setTheme] = useState('contacts-page-light-mode'); // Default to contacts-page-light-mode
 
     // Handle the toggle views
     const [viewMode, setViewMode] = useState('table'); // 'table', 'cards', or 'dashboard'
@@ -193,11 +192,6 @@ const ContactsPage = () => {
         handleGetContacts();
     }, []);
 
-    // Toggle between light and dark mode
-    const toggleTheme = () => {
-        setTheme(theme === 'contacts-page-light-mode' ? 'contacts-page-dark-mode' : 'contacts-page-light-mode');
-    };
-
     // Render the view as either table listing, cards, or the dasboard
     const renderView = () => {
         switch (viewMode) {
@@ -225,7 +219,7 @@ const ContactsPage = () => {
                 </div>
             // Display the dashboard metrics
             case 'dashboard':
-                return <ContactsMetrics />;
+                return <ContactsMetrics contacts={contacts} />;
             default:
                 return null;
         }
@@ -238,18 +232,23 @@ const ContactsPage = () => {
     return (
         <>
             <NavBar />
-            <div className={`${theme} contacts-page`}>
+            <div className={`contacts-page`}>
                 <div className="contacts-page-controls-container">
-                    <button className="contacts-page-toggle-theme-button" onClick={toggleTheme}>{theme === 'contacts-page-light-mode' ? 'Light Mode is On' : 'Dark Mode Is On'}</button>
                     <button className="contacts-page-add-new-contact-button" onClick={() => setShowAddModal(true)}>Add New Contact</button>
-                    <button className="contacts-page-toggle-dashboard-button" onClick={() => setViewMode('dashboard')}>Dashboard</button>
+                    <button className="contacts-page-toggle-dashboard-button" onClick={() => viewMode !== 'dashboard' ? setViewMode('dashboard') : setViewMode('table')}>{viewMode === 'dashboard' ? 'Contacts Table View' : 'Dashboard Metrics'}</button>
                 </div>
-                <span className="contacts-page-view-mode-text">{viewMode === 'cards' ? 'Card View' : 'Table View'}</span>
-                <div className="contacts-page-view-toggle">
-                    <input type="checkbox" id="contacts-page-viewModeToggle" className="contacts-page-view-mode-checkbox" hidden
-                        checked={viewMode === 'cards'} onChange={() => setViewMode(viewMode === 'table' ? 'cards' : 'table')} />
-                    <label htmlFor="contacts-page-viewModeToggle" className="contacts-page-view-mode-label"></label>
-                </div>
+                {viewMode !== 'dashboard' ? (
+                    <>
+                        <span className="contacts-page-view-mode-text">{viewMode === 'cards' ? 'Card View' : 'Table View'}</span>
+                        <div className="contacts-page-view-toggle">
+                            <input type="checkbox" id="contacts-page-viewModeToggle" className="contacts-page-view-mode-checkbox" hidden
+                                checked={viewMode === 'cards'} onChange={() => setViewMode(viewMode === 'table' ? 'cards' : 'table')} />
+                            <label htmlFor="contacts-page-viewModeToggle" className="contacts-page-view-mode-label"></label>
+                        </div>
+                    </>
+                ) : (
+                    <></>
+                )}
                 {/* If no contacts then display message */}
                 {contacts.length === 0 ? (
                     <>


### PR DESCRIPTION
Contacts metrics have been implemented w/ basic styling:

- Contacts by Contact Type custom pie chart using `<canvas>` element (required field)
- Contacts follow up date reminders or text displayed if none (optional field)
- Contacts breakdown of strength of connections and referral potential at each level (optional fields)
- Table breakdowns of other categories or text displayed if none for the category (optional categories)

The canvas element was tricky but things seem to be working. Did some minor cleanup on the Contacts page, and later I'll look at styling cleanups and I can also align with color schemes, etc.

<img width="744" alt="Screenshot 2024-02-16 at 9 00 03 PM" src="https://github.com/alesiram/cs467_capstone/assets/87046544/b94db780-e140-4b0b-8875-8f6c65fc4072">

Note: Scoped metric approaches with Bing/Gemini/Chat GPT and built w/ ChatGPT.