### PR TITLE
Babel Plugin Warning & Router Warning Fixes

### DIFF
--- a/tracker-ui/package-lock.json
+++ b/tracker-ui/package-lock.json
@@ -24,6 +24,9 @@
         "react-scripts": "5.0.1",
         "react-select": "^5.8.0",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -668,9 +671,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1906,6 +1917,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/tracker-ui/package.json
+++ b/tracker-ui/package.json
@@ -44,5 +44,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
   }
 }

--- a/tracker-ui/src/App.js
+++ b/tracker-ui/src/App.js
@@ -10,18 +10,12 @@ function App() {
   return (
     <div className="App">
       <Router>
-          {/* Route for the Home Page */}
-          <Route path="/" exact component={HomePage} />
-          <Route path='/login'>
-            <LoginPage />
-          </Route>
-          <Route path='/contacts'>
-            <ContactsPage />
-          </Route>
-          <Route path='/skills' exact component={SkillsPage}>
-            <SkillsPage />
-          </Route>
-          <Route path='/jobs' component={JobsPage}  /> 
+        {/* Component prop for all routes */}
+        <Route path="/" exact component={HomePage} />
+        <Route path="/login" exact component={LoginPage} />
+        <Route path="/contacts" exact component={ContactsPage} />
+        <Route path="/skills" exact component={SkillsPage} />
+        <Route path="/jobs" exact component={JobsPage} />
       </Router>
     </div>
   );


### PR DESCRIPTION
I used ChatGPT to help confirm the minor fixes below. I went through the app to confirm these changes did not impact anything and I did not see any issues, but let me know if otherwise.

**Babel Warning :**

_Warning before fix:_

```
One of your dependencies, babel-preset-react-app, is importing the
"@babel/plugin-proposal-private-property-in-object" package without
declaring it in its dependencies. This is currently working because
"@babel/plugin-proposal-private-property-in-object" is already in your
node_modules folder for unrelated reasons, but it may break at any time.

babel-preset-react-app is part of the create-react-app project, which
is not maintianed anymore. It is thus unlikely that this bug will
ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
your devDependencies to work around this error. This will make this message
go away.
```

The warning should no longer display as the direct dependency was added to the 'devDependencies' as shown in the package.json. ChatGPT said there is minimal risk to the existing functionality given the plugin was already being directly used, so explicity adding it as a devDependency does not change how the code compiles/behaves.

**Route component Warnings:**

_Warning before fix:_

![Screenshot 2024-03-08 at 2 16 30 PM](https://github.com/alesiram/cs467_capstone/assets/87046544/403a43ca-2868-4db3-84b6-09b729503bb9)

_No more warnings after fix:_

![Screenshot 2024-03-08 at 2 17 19 PM](https://github.com/alesiram/cs467_capstone/assets/87046544/dedef2b8-4985-452a-af40-c000613221f8)

We were encountering these warnings because we used both the 'component' prop and children inside a single `<Route>` This PR update is to align the approaches to use the component prop (i.e. use the same route definition for all), so the warning no longer appears. 