### PR TITLE
Skills cleanup

### DIFF
--- a/tracker-rest/controllers/skill_controller.mjs
+++ b/tracker-rest/controllers/skill_controller.mjs
@@ -113,10 +113,6 @@ export const getSkills = async (req, res) => {
 
         const skills = await Skill.aggregate(pipeline);
 
-        if (skills.length === 0) {
-            return res.status(404).json({ message: 'No skills found' });
-        }
-
         res.json(skills);
     } catch (error) {
         console.error(error);

--- a/tracker-rest/controllers/skill_controller.mjs
+++ b/tracker-rest/controllers/skill_controller.mjs
@@ -2,6 +2,7 @@
 
 import Skill from '../models/skill_model.mjs'; // Adjust the path as necessary
 import Contact from '../models/contact_model.mjs'; // Adjust the path as necessary
+//import ContactsMetricsFollowUps from '../../tracker-ui/src/components/ContactComponents/ContactsMetricsFollowUps';
 
 // Create a new skill
 export const createSkill = async (req, res) => {
@@ -222,4 +223,51 @@ export const getMostPopularSkill = async (req, res) => {
       res.status(500).json({ message: error.message });
     }
   };
+
+export const getAverageSkills = async (req, res) => {
+    try {
+        console.log(req)
+        const aggregation = await Skill.aggregate([
+            // Initial match stage if necessary, for example, to filter skills based on certain criteria
+            { $match: {} }, // Placeholder, adjust as needed
+
+            // Group by user and calculate the average rating for each user, along with counting the number of skills
+            {
+                $group: {
+                    _id: "$name",
+                    averageRating: { $avg: "$rating" },
+                    skillsCount: { $sum: 1 }
+                }
+            },
+            // Calculate the overall averages across all users
+            {
+                $group: {
+                    _id: null, // Grouping without a specific field to calculate overall averages
+                    averageNumberOfSkills: { $avg: "$skillsCount" },
+                    overallAverageRating: { $avg: "$averageRating" }
+                }
+            },
+            // Optionally, project the fields to provide a cleaner response, excluding the _id field
+            {
+                $project: {
+                    _id: 0,
+                    averageNumberOfSkills: 1,
+                    overallAverageRating: 1
+                }
+            }
+        ]);
+
+        if (aggregation.length === 0) {
+            return res.status(404).json({ message: 'No skills data found to calculate averages' });
+        }
+
+        // Return the calculated averages
+        res.json(aggregation[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Error calculating average skills: ' + error.message });
+    }
+};
+
+
   

--- a/tracker-rest/server.mjs
+++ b/tracker-rest/server.mjs
@@ -47,6 +47,7 @@ app.delete('/contacts/:id', authMiddleware, contact.deleteContact);
 
 // Route to get the most popular skills
 app.get('/skills/popular', authMiddleware, skill.getMostPopularSkill);
+app.get('/skills/averages', authMiddleware, skill.getAverageSkills)
 // Routes for skills (protected routes - must be auth'd)
 app.post('/skills', authMiddleware, skill.createSkill);
 app.get('/skills', authMiddleware, skill.getSkills);

--- a/tracker-ui/src/components/SkillComponents/SkillMetricsModal.js
+++ b/tracker-ui/src/components/SkillComponents/SkillMetricsModal.js
@@ -1,0 +1,66 @@
+// SkillMetricsModal.js
+import React, { useState, useEffect } from 'react';
+
+const SkillMetricsModal = ({ onClose }) => {
+  const [metrics, setMetrics] = useState({ mostPopularSkill: null, averageSkills: null });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchMetrics = async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const token = localStorage.getItem('token');
+      // Fetch most popular skill
+      const popularSkillResponse = await fetch('/skills/popular', {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      const popularSkillData = await popularSkillResponse.json();
+      
+      // Fetch average skills and rating
+      const averageSkillsResponse = await fetch('/skills/averages', {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      const averageSkillsData = await averageSkillsResponse.json();
+      
+      if (!popularSkillResponse.ok || !averageSkillsResponse.ok) {
+        throw new Error('Failed to fetch skill metrics');
+      }
+
+      setMetrics({
+        mostPopularSkill: popularSkillData,
+        averageSkills: averageSkillsData,
+      });
+    } catch (error) {
+      setError('Failed to load skill metrics');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMetrics();
+  }, []);
+
+  return (
+    <div className="skills-page__modal-backdrop">
+      <div className="skills-page__modal" role="dialog" aria-modal="true" aria-labelledby="metricsModalTitle">
+        <h2 id="metricsModalTitle">Skill Metrics</h2>
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p>{error}</p>
+        ) : (
+          <div>
+            <p>The most popular skill is {metrics.mostPopularSkill?._id} with an average rating of {metrics.mostPopularSkill?.averageRating.toFixed(1)}!</p>
+            <p>The average user has {metrics.averageSkills?.averageNumberOfSkills.toFixed(1)} skills!</p>
+            <p>Their average skill is rated at {metrics.averageSkills?.overallAverageRating.toFixed(1)}!</p>
+          </div>
+        )}
+        <button type="button" className="skills-page__button--cancel" onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+};
+
+export default SkillMetricsModal;

--- a/tracker-ui/src/pages/skills/skills.css
+++ b/tracker-ui/src/pages/skills/skills.css
@@ -129,7 +129,8 @@
 }
 
 .skills-page__action-button--edit:hover,
-.skills-page__action-button--delete:hover {
+.skills-page__action-button--delete:hover,
+.skills-page__action-button--clear:hover {
   filter: brightness(110%);
   transform: translateY(-2px);
 }
@@ -216,6 +217,7 @@
   height: 40px; /* Example fixed height */
   padding: 8px;
   font-size: 16px; /* Ensure font size is consistent */
+  width: 100%;
   /* Optional: Define a specific width or use flex-grow if within a flex container for alignment */
 }
 
@@ -253,7 +255,7 @@
   margin: 20px 0; /* Margin for spacing around the error message */
   text-align: center; /* Centered text for emphasis */
   font-size: 0.9rem; /* Slightly smaller font size for distinction */
-  width: 100%;
+  width: 75%;
 }
 
 /* Skills page header icon styling */

--- a/tracker-ui/src/pages/skills/skills.css
+++ b/tracker-ui/src/pages/skills/skills.css
@@ -48,7 +48,8 @@
 .skills-page__button--add-new,
 .skills-page__button--save,
 .skills-page__button--cancel,
-.skills-page__button--delete {
+.skills-page__button--delete,
+.skills-page__button--metrics {
   background-color: var(--secondary-color);
   color: var(--button-text-color);
   border: none;
@@ -66,14 +67,16 @@
 }
 
 .skills-page__button--add-new,
-.skills-page__button--save {
+.skills-page__button--save,
+.skills-page__button--metrics {
   background-color: var(--primary-color); /* Adjusted to primary orange */
 }
 
 .skills-page__button--add-new:hover,
 .skills-page__button--save:hover,
 .skills-page__button--cancel:hover,
-.skills-page__button--delete:hover {
+.skills-page__button--delete:hover,
+.skills-page__button--metrics:hover {
   filter: brightness(110%);
   transform: translateY(-2px);
 }
@@ -222,7 +225,8 @@
 }
 
 /* Additional styling for overall filter container for alignment and spacing */
-.skills-page__filters {
+.skills-page__filters,
+.skills-page__add-and-metrics {
   display: flex;
   justify-content: flex-start; /* Align items to the start of the container */
   align-items: center; /* Center items vertically */

--- a/tracker-ui/src/pages/skills/skills.js
+++ b/tracker-ui/src/pages/skills/skills.js
@@ -8,11 +8,12 @@ import AddSkillModal from '../../components/SkillComponents/AddSkillModal';
 import EditSkillModal from '../../components/SkillComponents/EditSkillModal';
 import DeleteSkillModal from '../../components/SkillComponents/DeleteSkillModal';
 import ViewContactModal from '../../components/ContactComponents/ViewContactModal';
+import SkillMetricsModal from '../../components/SkillComponents/SkillMetricsModal';
 
 // Icons
 import SkillsIcon from '@mui/icons-material/Build';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
-//import DashboardIcon from '@mui/icons-material/Dashboard';
+import DashboardIcon from '@mui/icons-material/Dashboard';
 
 // Assuming './skills.css' and NavBar, SkillTable, AddSkillModal, EditSkillModal, DeleteSkillModal are correctly implemented
 import './skills.css';
@@ -32,6 +33,7 @@ const SkillsPage = () => {
   const [isLoadingPopularSkill, setIsLoadingPopularSkill] = useState(false);
   const [showViewModal, setShowViewModal] = useState(false);
   const [currentContact, setCurrentContact] = useState({});
+  const [showMetricsModal, setShowMetricsModal] = useState(false);
 
 
   // Combined fetch function for skills and contacts
@@ -278,21 +280,14 @@ const SkillsPage = () => {
         <SkillsIcon style={{ marginRight: '8px', verticalAlign: 'middle' }} fontSize="large" />
         <h1>SKILLS</h1>
       </div>
-
-        
-        {/* Displaying the most popular skill summary */}
-        {mostPopularSkill ? (
-          <div className="skills-page__most-popular-summary">
-            <p>Most Popular Skill: {mostPopularSkill._id}</p>
-            <p>Average Rating: {mostPopularSkill.averageRating.toFixed(1)}</p>
-          </div>
-        ) : isLoadingPopularSkill ? (
-          <p>Loading most popular skill...</p>
-        ) : null}
-        
-        <button className="skills-page__button--add-new"  onClick={() => setShowAddModal(true)}>
-          <AddCircleIcon sx={{ color: 'var(--button-text-color' }} /> Add New Skill 
-        </button>
+        <div className="skills-page__add-and-metrics">
+          <button className="skills-page__button--add-new"  onClick={() => setShowAddModal(true)}>
+            <AddCircleIcon sx={{ color: 'var(--button-text-color' }} /> Add New Skill 
+          </button>
+          <button onClick={() => setShowMetricsModal(true)} className="skills-page__button--metrics">
+            <DashboardIcon sx={{ color: 'var(--button-text-color' }} />View Skill Metrics
+          </button>
+        </div>
         
         <div className="skills-page__filters">
           <input
@@ -316,6 +311,7 @@ const SkillsPage = () => {
         />
         
         {showAddModal && <AddSkillModal onClose={() => setShowAddModal(false)} onSave={addSkill} contacts={contacts} />}
+        {showMetricsModal && <SkillMetricsModal onClose={() => setShowMetricsModal(false)} />}
         {showEditModal && currentSkill && <EditSkillModal skill={currentSkill} onClose={() => setShowEditModal(false)} onSave={editSkill} contacts={contacts} />}
         {showDeleteModal && currentSkill && <DeleteSkillModal skill={currentSkill} onClose={() => setShowDeleteModal(false)} onDelete={deleteSkill} />}
         {currentContact && (<ViewContactModal show={showViewModal} onClose={handleCloseModal} contact={currentContact} />)}

--- a/tracker-ui/src/pages/skills/skills.js
+++ b/tracker-ui/src/pages/skills/skills.js
@@ -27,10 +27,8 @@ const SkillsPage = () => {
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [currentSkill, setCurrentSkill] = useState(null);
-  const [mostPopularSkill, setMostPopularSkill] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortCriteria, setSortCriteria] = useState({ field: 'name', order: 'asc' });
-  const [isLoadingPopularSkill, setIsLoadingPopularSkill] = useState(false);
   const [showViewModal, setShowViewModal] = useState(false);
   const [currentContact, setCurrentContact] = useState({});
   const [showMetricsModal, setShowMetricsModal] = useState(false);
@@ -38,7 +36,6 @@ const SkillsPage = () => {
 
   // Combined fetch function for skills and contacts
   const fetchData = useCallback(async () => {
-    //setIsLoading(true);
     setError(''); // Reset error message at the beginning of a fetch operation
     try {
       const token = localStorage.getItem('token');
@@ -76,7 +73,6 @@ const SkillsPage = () => {
       setError('No results match!');
       setSkills([]); // Ensure the skills list is cleared on error
     } finally {
-      //setIsLoading(false);
     }
   }, [searchTerm]);
   
@@ -123,48 +119,12 @@ const SkillsPage = () => {
     setShowEditModal(true);
   }
   
-  // Correctly define fetchMostPopularSkill within SkillsPage component
-  const fetchMostPopularSkill = async () => {
-    setIsLoadingPopularSkill(true); // Assume you have a separate loading state for this operation
-    try {
-      const token = localStorage.getItem('token');
-      const response = await fetch('/skills/popular', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-  
-      if (!response.ok) {
-        // If the server response is not ok, throw an error with the status text
-        throw new Error(`Failed to fetch the most popular skill: ${response.statusText}`);
-      }
-  
-      const data = await response.json();
-      // Assuming the backend sends the most popular skill in the expected format
-      // directly set the received data to your state
-      setMostPopularSkill(data);
-    } catch (error) {
-      // Catch any errors that occur during the fetch operation
-      setError(`Failed to load the most popular skill: ${error.message}`);
-    } finally {
-      // Whether successful or not, indicate that loading is complete
-      setIsLoadingPopularSkill(false);
-    }
-  };
-  
   useEffect(() => {
     fetchData();
   }, [fetchData]); // Removed sortCriteria from dependencies
   
-  useEffect(() => {
-    fetchMostPopularSkill();
-  }, []); // Empty dependency array ensures this runs only once on component mount
-  
   // Add skill
   const addSkill = async (skill) => {
-    //setIsLoading(true);
     try {
       const token = localStorage.getItem('token');
       const response = await fetch('/skills', {
@@ -189,14 +149,12 @@ const SkillsPage = () => {
     } catch (error) {
       setError(error.message);
     } finally {
-      //setIsLoading(false);
     }
   };
 
 
   // Edit skill
   const editSkill = async (skill) => {
-    //setIsLoading(true);
     try {
       const token = localStorage.getItem('token');
       const response = await fetch(`/skills/${skill._id}`, {
@@ -218,13 +176,11 @@ const SkillsPage = () => {
     } catch (error) {
       setError(error.message);
     } finally {
-      //setIsLoading(false);
     }
   };
 
   // Delete skill
   const deleteSkill = async (skillId) => {
-    //setIsLoading(true);
     try {
       const token = localStorage.getItem('token');
       const response = await fetch(`/skills/${skillId}`, {
@@ -245,7 +201,6 @@ const SkillsPage = () => {
     } catch (error) {
       setError(error.message);
     } finally {
-      //setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
Changes include:

- Adjustment of skill metrics to their own modal.
![image](https://github.com/alesiram/cs467_capstone/assets/76988576/3663de65-6ddb-4f9c-b161-608b878ffb18)

- General cleanup (removal of unused variables, add metrics button, etc.).
- Fixed 404 error when there are no skills for a user.

I believe the new aggregation for metrics will throw a 404 when there are no skills at a site-wide level (and there is front-end error handling so it won't crash). I'm open to handling on the backend if we think that is a better solution, but I figured it wouldn't be an unreasonable error since it'd only occur upon initial startup of the site/userbase. 