### PR TITLE
Removed 'Unique' from Schema Contact Name

### DIFF
--- a/tracker-rest/models/contact_model.mjs
+++ b/tracker-rest/models/contact_model.mjs
@@ -10,7 +10,6 @@ const contactSchema = new mongoose.Schema({
     name: {
         type: String,
         required: true,
-        unique: true
     },
     company: {
         type: String,


### PR DESCRIPTION
I noticed that two different users could not have a contact with the same name due to the schema restraint (would result in POST error). Removed the 'unique' keyword from the schema to allow multiple site users to have contacts with the same name. Contact name uniqueness per user is still enforced on the front end. For example, a single user can't have duplicate contacts with the same name, but multiple site users can each have a contact with the same name - so the setup now makes more sense.